### PR TITLE
Make URLs to Have Trailing Slash, Compatible with Old Website URLs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,7 +8,7 @@ const nextConfig = {
     path: '',
     unoptimized: true,
   },
-
+  trailingSlash: true,
 }
 
 export default nextConfig


### PR DESCRIPTION
- e.g. `/minutes/` on old websites got trailing slash
- The change will make some of those URLs work again in export build
- The URLs with trailing slash will be the "canonical", and without trailing slash will be redirected
- resolves #17 