### PR TITLE
fix: refactor index for a team

### DIFF
--- a/components/teamList/TeamList.tsx
+++ b/components/teamList/TeamList.tsx
@@ -1,23 +1,19 @@
-import { TEAM } from '@/constants/team'
 import TeamCard from './TeamCard'
+import { Fragment } from 'react'
+import { TEAM } from '@constants/team'
+import { sortRecordKeysDesc } from '@utils/utils'
 
 const TeamList = () => {
-  return Object.keys(TEAM)
-    .sort()
-    .reverse()
-    .map((year: string) => (
-      <>
-        <h1 className="font-space-mono text-3xl my-10">{year}</h1>
-        <div
-          key={year}
-          className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4 "
-        >
-          {TEAM[year].map((person) => (
-            <TeamCard key={person.name} person={person} />
-          ))}
-        </div>
-      </>
-    ))
+  return sortRecordKeysDesc(TEAM).map(([year, people]) => (
+    <Fragment key={year}>
+      <h1 className="font-space-mono text-3xl my-10">{year}</h1>
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">
+        {people.map((person) => (
+          <TeamCard key={`${year}-${person.role}`} person={person} />
+        ))}
+      </div>
+    </Fragment>
+  ))
 }
 
 export default TeamList

--- a/components/welcomesection/PresidentQuoteSection.tsx
+++ b/components/welcomesection/PresidentQuoteSection.tsx
@@ -1,11 +1,10 @@
 import PRESIDENT_QUOTE from '@/constants/presidentsQuote'
-import { TEAM } from '@/constants/team'
+import { latestYear, TEAM } from '@/constants/team'
 import { prefix } from '@/utils/prefix'
 import Image from 'next/image'
 import VariableBackgroundSwitcher from '../VariableBackgroundSwitcher'
 
 const PresidentQuoteSection = () => {
-  const latestYear = Object.keys(TEAM).sort().reverse()[0]
   const president = TEAM[latestYear].find(
     (person) => person.role === 'President'
   )

--- a/types/team.ts
+++ b/types/team.ts
@@ -22,26 +22,29 @@ export enum Role {
   EU_LUG = 'EU LUG',
 }
 
-const roleEmails: Partial<{ [key in Role]: string }> = {
-  [Role.PRESIDENT]: 'president@comp-soc.com',
-  [Role.VICE_PRESIDENT]: 'vicepresident@comp-soc.com',
-  [Role.TREASURER]: 'treasurer@comp-soc.com',
-  [Role.JUNIOR_TREASURER]: 'jrtreasurer@comp-soc.com',
-  [Role.SECRETARY]: 'secretary@comp-soc.com',
-  [Role.TECHNICAL_SECRETARY]: 'techsec@comp-soc.com',
-  [Role.SOCIAL_SECRETARY]: 'socialsec@comp-soc.com',
-  [Role.SOCIAL_MEDIA_OFFICER]: 'socialmedia@comp-soc.com',
-  [Role.GRAPHIC_DESIGNER]: 'graphicdesigner@comp-soc.com',
-  [Role.FIRST_YEAR_REP]: 'freshersrep@comp-soc.com',
-  [Role.SECOND_YEAR_REP]: 'secondrep@comp-soc.com',
-  [Role.THIRD_YEAR_REP]: 'thirdrep@comp-soc.com',
-  [Role.FOURTH_YEAR_REP]: 'fourthrep@comp-soc.com',
-  [Role.OLD_PERSON_REP]: 'oldrep@comp-soc.com',
-  [Role.EDI_REP]: 'edirep@comp-soc.com',
-}
+// Moving to a separate file as a separate model?
+export namespace Role {
+  const roleEmails: Partial<Record<Role, string>> = {
+    [Role.PRESIDENT]: 'president@comp-soc.com',
+    [Role.VICE_PRESIDENT]: 'vicepresident@comp-soc.com',
+    [Role.TREASURER]: 'treasurer@comp-soc.com',
+    [Role.JUNIOR_TREASURER]: 'jrtreasurer@comp-soc.com',
+    [Role.SECRETARY]: 'secretary@comp-soc.com',
+    [Role.TECHNICAL_SECRETARY]: 'techsec@comp-soc.com',
+    [Role.SOCIAL_SECRETARY]: 'socialsec@comp-soc.com',
+    [Role.SOCIAL_MEDIA_OFFICER]: 'socialmedia@comp-soc.com',
+    [Role.GRAPHIC_DESIGNER]: 'graphicdesigner@comp-soc.com',
+    [Role.FIRST_YEAR_REP]: 'freshersrep@comp-soc.com',
+    [Role.SECOND_YEAR_REP]: 'secondrep@comp-soc.com',
+    [Role.THIRD_YEAR_REP]: 'thirdrep@comp-soc.com',
+    [Role.FOURTH_YEAR_REP]: 'fourthrep@comp-soc.com',
+    [Role.OLD_PERSON_REP]: 'oldrep@comp-soc.com',
+    [Role.EDI_REP]: 'edirep@comp-soc.com',
+  }
 
-export function getEmailForRole(role: Role): string | undefined {
-  return roleEmails[role]
+  export function getEmailByRole(role: Role): string | undefined {
+    return roleEmails[role]
+  }
 }
 
 export enum LinkType {

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -1,6 +1,12 @@
 import clsx, { ClassValue } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 
+export function sortRecordKeysDesc<T>(
+  record: Record<string, T>
+): [string, T][] {
+  return Object.entries(record).sort(([a], [b]) => Number(b) - Number(a))
+}
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }


### PR DESCRIPTION
While poking around in the code, I found an interesting spot where we mutate a map to insert an email into an object)

I wouldn’t say I’ve resolved the issue, but I’d be interested in revisiting it later.

In this PR, I’ve updated the sorting approach and simplified the team index code.

In the future, I think it would be nice to access committee members like `TEAM.President or TEAM.AnyRole` instead of using `team[latestYear].filter(...)`.