### PR TITLE
feat: make a new design for a calendar view

### DIFF
--- a/components/EventModal.tsx
+++ b/components/EventModal.tsx
@@ -1,0 +1,172 @@
+import { FC } from 'react'
+import Modal from '@mui/material/Modal'
+import Box from '@mui/material/Box'
+import Image from 'next/image'
+import { MapPin, Calendar, Clock, User, Xmark } from 'iconoir-react'
+import { prefix } from '@/utils/prefix'
+
+interface EventModalProps {
+  open: boolean
+  onClose: () => void
+  event: any
+  isMobile: boolean
+}
+
+const EventModal: FC<EventModalProps> = ({
+  open,
+  onClose,
+  event,
+  isMobile,
+}) => {
+  const createMarkup = (html: string) => {
+    if (!html) return { __html: '' }
+    return {
+      __html: html.replace(
+        /<a /g,
+        '<a style="color: #CE3234; text-decoration: underline; font-weight: 500;" '
+      ),
+    }
+  }
+
+  const renderEventLocation = () => {
+    if (!event?.extendedProps?.location) return null
+
+    return (
+      <div className="mb-5 p-4 bg-cslightgrey rounded-lg">
+        <div className="flex items-start gap-3">
+          <MapPin className="w-5 h-5 text-csred mt-0.5 flex-shrink-0" />
+          <div>
+            <h3 className="text-sm font-medium text-textPrimary mb-1.5 font-space-mono">
+              Location
+            </h3>
+            <p className="text-sm text-textSecondary font-space-mono">
+              {event.extendedProps.location}
+            </p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  const renderEventDescription = () => {
+    if (!event?.extendedProps?.description) {
+      return (
+        <div className="text-center py-8">
+          <User className="w-8 h-8 text-textSecondary mx-auto mb-3" />
+          <p className="text-sm text-textSecondary font-space-mono">
+            No additional details available.
+          </p>
+        </div>
+      )
+    }
+
+    return (
+      <div id="event-modal-description" className="space-y-3">
+        <h3 className="text-sm font-medium text-textPrimary font-space-mono flex items-center gap-2">
+          <User className="w-4 h-4" />
+          Details
+        </h3>
+        <div
+          className="prose prose-sm max-w-none text-textSecondary leading-relaxed font-space-mono text-sm"
+          dangerouslySetInnerHTML={createMarkup(
+            event.extendedProps.description
+          )}
+        />
+      </div>
+    )
+  }
+
+  const renderEventHeader = () => (
+    <div className="relative bg-csgrey p-5 sm:p-6 border-b border-border">
+      <button
+        onClick={onClose}
+        className="absolute top-4 right-4 p-2 rounded-full hover:bg-cslightgrey transition-colors duration-200"
+        aria-label="Close modal"
+      >
+        <Xmark className="w-5 h-5 text-textPrimary" />
+      </button>
+
+      <div className="flex items-start gap-4">
+        <div className="flex-shrink-0">
+          <Image
+            width={isMobile ? 40 : 48}
+            height={isMobile ? 40 : 48}
+            src={`${prefix}/SIGs/${event.extendedProps.sig.icon.src}`}
+            alt={event.extendedProps.sig.icon.alt}
+            className={`${
+              event.extendedProps.sig.icon.rounded
+                ? 'rounded-full'
+                : 'rounded-lg'
+            } shadow-lg`}
+          />
+        </div>
+
+        <div className="flex-1 min-w-0 space-y-2">
+          <h2
+            id="event-modal-title"
+            className="text-lg sm:text-xl font-tomorrow font-semibold text-textPrimary leading-tight"
+          >
+            {event.title}
+          </h2>
+
+          <div className="flex items-center gap-2 text-sm text-textSecondary">
+            <Calendar className="w-4 h-4" />
+            <span className="font-space-mono">
+              {event.extendedProps.formattedDate}
+            </span>
+            {event.start && (
+              <>
+                <Clock className="w-4 h-4 ml-2" />
+                <span className="font-space-mono">
+                  {event.start.toLocaleTimeString([], {
+                    hour: '2-digit',
+                    minute: '2-digit',
+                  })}
+                </span>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+
+  if (!event) return null
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      aria-labelledby="event-modal-title"
+      aria-describedby="event-modal-description"
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        p: { xs: 1, sm: 2 },
+      }}
+    >
+      <Box
+        sx={{
+          bgcolor: '#222222',
+          boxShadow: '0 25px 50px -12px rgba(0, 0, 0, 0.6)',
+          borderRadius: '12px',
+          width: { xs: '95%', sm: '90%' },
+          maxWidth: '500px',
+          maxHeight: { xs: '85vh', sm: '80vh' },
+          overflow: 'hidden',
+          outline: 'none',
+        }}
+      >
+        {renderEventHeader()}
+
+        <div className="p-5 sm:p-6 max-h-[calc(80vh-200px)] overflow-y-auto">
+          {renderEventLocation()}
+          {renderEventDescription()}
+        </div>
+      </Box>
+    </Modal>
+  )
+}
+
+export default EventModal

--- a/components/calendar/CalendarErrorState.tsx
+++ b/components/calendar/CalendarErrorState.tsx
@@ -1,0 +1,32 @@
+import { FC } from 'react'
+import { Calendar } from 'iconoir-react'
+
+interface CalendarErrorStateProps {
+  message?: string
+  onRetry?: () => void
+}
+
+const CalendarErrorState: FC<CalendarErrorStateProps> = ({
+  message = 'Unable to load events',
+  onRetry,
+}) => {
+  return (
+    <div className="bg-csgrey rounded-2xl border border-border p-8 text-center">
+      <Calendar className="w-12 h-12 text-textSecondary mx-auto mb-4" />
+      <h3 className="text-xl font-tomorrow text-textPrimary mb-2">{message}</h3>
+      <p className="text-textSecondary font-space-mono mb-4">
+        Please try refreshing the page or check back later.
+      </p>
+      {onRetry && (
+        <button
+          onClick={onRetry}
+          className="px-4 py-2 bg-csred text-textPrimary rounded-lg font-space-mono hover:bg-csred/80 transition-colors duration-200"
+        >
+          Try Again
+        </button>
+      )}
+    </div>
+  )
+}
+
+export default CalendarErrorState

--- a/components/calendar/CalendarHeader.tsx
+++ b/components/calendar/CalendarHeader.tsx
@@ -1,0 +1,30 @@
+import { FC, ReactNode } from 'react'
+
+interface CalendarHeaderProps {
+  title?: string
+  description?: string
+  children?: ReactNode
+}
+
+const CalendarHeader: FC<CalendarHeaderProps> = ({
+  title = 'Events',
+  description = 'CompSoc activities and events',
+  children,
+}) => {
+  return (
+    <div className="calendar-header">
+      <div className="flex flex-col lg:flex-row items-start lg:items-center justify-between gap-4">
+        <div>
+          <h2 className="calendar-title mb-1">{title}</h2>
+          <p className="text-textSecondary font-space-mono text-xs">
+            {description}
+          </p>
+        </div>
+
+        {children}
+      </div>
+    </div>
+  )
+}
+
+export default CalendarHeader

--- a/components/calendar/CalendarLoader.tsx
+++ b/components/calendar/CalendarLoader.tsx
@@ -1,0 +1,46 @@
+const CalendarLoader = () => {
+  return (
+    <div className="bg-csgrey rounded-lg border border-border overflow-hidden">
+      <div className="p-6 border-b border-border">
+        <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
+          <div className="w-48 h-8 bg-cslightgrey rounded-lg animate-pulse"></div>
+          <div className="flex gap-2">
+            {Array.from({ length: 4 }, (_, i) => (
+              <div
+                key={`header-btn-${i}`}
+                className="w-16 h-8 bg-cslightgrey rounded-md animate-pulse"
+              ></div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="p-6">
+        <div className="grid grid-cols-7 gap-1 mb-4">
+          {['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'].map((day) => (
+            <div
+              key={`header-${day}`}
+              className="h-8 bg-cslightgrey rounded animate-pulse"
+            ></div>
+          ))}
+        </div>
+
+        <div className="space-y-2">
+          {Array.from({ length: 6 }, (_, i) => (
+            <div key={`week-row-${i}`} className="grid grid-cols-8 gap-1">
+              <div className="h-16 bg-foreground rounded animate-pulse"></div>
+              {Array.from({ length: 7 }, (_, j) => (
+                <div
+                  key={`week-cell-${i}-${j}`}
+                  className="h-16 bg-foreground rounded animate-pulse"
+                ></div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default CalendarLoader

--- a/components/calendar/CalendarNavigation.tsx
+++ b/components/calendar/CalendarNavigation.tsx
@@ -1,0 +1,104 @@
+import { FC } from 'react'
+import { ArrowLeft, ArrowRight } from 'iconoir-react'
+
+interface CalendarNavigationProps {
+  isMobile: boolean
+  calendarView: string
+  onPrevious: () => void
+  onNext: () => void
+  onToday: () => void
+  onViewChange: (view: string) => void
+}
+
+const CalendarNavigation: FC<CalendarNavigationProps> = ({
+  isMobile,
+  calendarView,
+  onPrevious,
+  onNext,
+  onToday,
+  onViewChange,
+}) => {
+  const navigationButtons = [
+    {
+      key: 'day',
+      label: 'Day',
+      view: 'timeGridDay',
+      isActive: calendarView === 'timeGridDay',
+    },
+    {
+      key: 'week',
+      label: 'Week',
+      view: 'timeGridWeek',
+      isActive: calendarView === 'timeGridWeek',
+      showOnMobile: false,
+    },
+    {
+      key: 'month',
+      label: 'Month',
+      view: 'dayGridMonth',
+      isActive: calendarView === 'dayGridMonth',
+      showOnMobile: false,
+    },
+  ]
+
+  const renderArrowControls = () => (
+    <div className="flex gap-1">
+      <button
+        onClick={onPrevious}
+        className="nav-arrow-btn"
+        aria-label="Previous period"
+      >
+        <ArrowLeft className="w-4 h-4" />
+      </button>
+      <button
+        onClick={onToday}
+        className="calendar-nav-btn"
+        aria-label="Go to today"
+      >
+        Today
+      </button>
+      <button
+        onClick={onNext}
+        className="nav-arrow-btn"
+        aria-label="Next period"
+      >
+        <ArrowRight className="w-4 h-4" />
+      </button>
+    </div>
+  )
+
+  const renderViewControls = () => (
+    <div className="flex gap-1">
+      {navigationButtons
+        .filter((btn) => !isMobile || btn.showOnMobile !== false)
+        .map((btn) => (
+          <button
+            key={btn.key}
+            onClick={() => onViewChange(btn.view)}
+            className={`calendar-nav-btn ${btn.isActive ? 'active' : ''}`}
+            aria-label={`Switch to ${btn.label.toLowerCase()} view`}
+          >
+            {btn.label}
+          </button>
+        ))}
+    </div>
+  )
+
+  if (isMobile) {
+    return (
+      <div className="mobile-nav-container lg:hidden">
+        <div className="mobile-nav-top">{renderArrowControls()}</div>
+        <div className="mobile-view-controls">{renderViewControls()}</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="desktop-nav-container hidden lg:flex items-center gap-5">
+      {renderArrowControls()}
+      {renderViewControls()}
+    </div>
+  )
+}
+
+export default CalendarNavigation


### PR DESCRIPTION
I’ve been using the events page quite a lot and noticed that the calendar experience isn’t ideal on mobile, and the overall UX could use some improvements. I’ve started working on enhancements focused on improving the UI/UX - especially for the calendar view.

This PR includes:
• A redesigned modal window optimised for mobile
• Improved responsiveness and touch interactions
• UI with animations for a smoother user experience

Screenshots of the redesigned calendar view are attached below.
<img width="924" alt="calendar" src="https://github.com/user-attachments/assets/4f48aaaa-efaf-4da3-aab6-0e930293376f" />
<img width="875" alt="loading" src="https://github.com/user-attachments/assets/8fc99e2f-4fdf-43d3-ba1c-3d8f33f31102" />
<img width="477" alt="modal" src="https://github.com/user-attachments/assets/3b3aaab4-8bb9-4b90-95dc-bee3bc3dea5c" />

