### PR TITLE
feat: refresh news and minutes page design

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -8,21 +8,21 @@ export default function Events() {
   return (
     <div className="max-w-5xl mx-auto">
       <div className="pt-4">
-        <Heading title="Full event calendar"></Heading>
+        <Heading title="Full event calendar" />
         <div className="mt-6 font-space-mono">
           Aside from the large events, CompSoc and its SIGs run a variety of
           events each week. Explore our full event calendar below and find out
           what&apos;s coming up!
         </div>
-        <EventsCalendar></EventsCalendar>
+        <EventsCalendar />
 
         <div className="mt-10">
-          <Heading title="Flagship Events"></Heading>
+          <Heading title="Flagship Events" />
           <div className="mt-6 pb-6 font-space-mono">
             These are big events we run every year without fail. Consider
             joining us for one of these!
           </div>
-          <EventCard></EventCard>
+          <EventCard />
         </div>
       </div>
     </div>

--- a/app/minutes/MinutesList.tsx
+++ b/app/minutes/MinutesList.tsx
@@ -1,40 +1,156 @@
 'use client'
 
-import SearchPosts from '@/components/SearchPosts'
 import { prefix } from '@/utils/prefix'
-import Image from 'next/image'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
+import { Search, Filter, X } from 'iconoir-react'
+import Heading from '@/components/heading'
 
-const MinuteFile = ({ slug, intro }: { slug: string; intro: string }) => {
+const SearchBar = ({
+  searchQuery,
+  setSearchQuery,
+  onFilterChange,
+  yearFilter,
+  availableYears,
+}: {
+  searchQuery: string
+  setSearchQuery: (query: string) => void
+  onFilterChange: (year: string) => void
+  yearFilter: string
+  availableYears: string[]
+}) => {
+  const [showFilters, setShowFilters] = useState(false)
+
   return (
-    <Link href={`${prefix}/minutes/${slug}`}>
-      <div className="border border-border p-4 rounded-sm bg-foreground">
-        <h2 className="text-xl font-space-mono">{slug}</h2>
-        <p
-          style={{
-            display: '-webkit-box',
-            WebkitLineClamp: 5,
-            WebkitBoxOrient: 'vertical',
-            overflow: 'hidden',
-            position: 'relative',
-          }}
-        >
-          <span className="opacity-70">{intro}</span>
-          <span
-            style={{
-              position: 'absolute',
-              bottom: 0,
-              left: 0,
-              right: 0,
-              height: '10em',
-              background:
-                'linear-gradient(to bottom, rgba(255,255,255,0) 0%, #353535 100%)',
-            }}
+    <div className="mb-8">
+      <div className="relative flex flex-col sm:flex-row gap-4 items-center">
+        <div className="relative flex-1 max-w-md">
+          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-zinc-400 w-5 h-5" />
+          <input
+            type="text"
+            placeholder="Search minutes, topics, or dates..."
+            className="w-full pl-10 pr-4 py-3 bg-foreground border border-border  focus:outline-none focus:ring-2 focus:ring-csred/50 focus:border-csred transition-all duration-200 font-space-mono text-sm"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
           />
-        </p>
+          {searchQuery && (
+            <button
+              onClick={() => setSearchQuery('')}
+              className="absolute right-3 top-1/2 transform -translate-y-1/2 text-zinc-400 hover:text-white transition-colors"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          )}
+        </div>
+
+        <button
+          onClick={() => setShowFilters(!showFilters)}
+          className="flex items-center gap-2 px-4 py-3 bg-foreground border border-border  hover:bg-border/50 transition-colors font-space-mono text-sm"
+        >
+          <Filter className="w-4 h-4" />
+          Filters
+          {yearFilter && (
+            <span className="bg-csred text-white px-2 py-1 rounded-full text-xs">
+              {yearFilter}
+            </span>
+          )}
+        </button>
       </div>
-    </Link>
+
+      {showFilters && (
+        <div className="mt-4 p-4 bg-foreground border border-border ">
+          <div className="flex flex-wrap gap-2">
+            <button
+              onClick={() => onFilterChange('')}
+              className={`px-3 py-2  text-sm font-space-mono transition-colors ${
+                !yearFilter
+                  ? 'bg-csred text-white'
+                  : 'bg-border text-zinc-300 hover:bg-border/70'
+              }`}
+            >
+              All Years
+            </button>
+            {availableYears.map((year) => (
+              <button
+                key={year}
+                onClick={() => onFilterChange(year)}
+                className={`px-3 py-2  text-sm font-space-mono transition-colors ${
+                  yearFilter === year
+                    ? 'bg-csred text-white'
+                    : 'bg-border text-zinc-300 hover:bg-border/70'
+                }`}
+              >
+                {year}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+const ListView = ({
+  filteredPosts,
+  initialPostsToShow,
+  setInitialPostsToShow,
+}: {
+  filteredPosts: {
+    slug: string
+    content: string
+    date: string
+    title: string
+  }[]
+  initialPostsToShow: number
+  setInitialPostsToShow: (count: number) => void
+}) => {
+  return (
+    <div>
+      {filteredPosts.slice(0, initialPostsToShow).map((post, index) => (
+        <Link key={post.slug} href={`${prefix}/minutes/${post.slug}`}>
+          <div className="group mt-4 border border-border p-4  bg-foreground hover:bg-border/30 transition-all duration-200 hover:scale-[1.01]">
+            <div className="flex items-center justify-between">
+              <div className="flex-1">
+                <h3 className="text-lg font-tomorrow text-white group-hover:text-csred transition-colors">
+                  {new Date(post.date).toLocaleDateString('en-GB', {
+                    day: 'numeric',
+                    month: 'short',
+                    year: 'numeric',
+                  })}
+                </h3>
+                <span className="text-sm text-zinc-400 font-space-mono">
+                  {new Date(post.date).toLocaleDateString('en-GB', {
+                    weekday: 'long',
+                  })}
+                </span>
+              </div>
+            </div>
+            <p
+              className="text-sm opacity-70 leading-relaxed mt-2"
+              style={{
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+              }}
+            >
+              {post.content.slice(0, 180)}...
+            </p>
+          </div>
+        </Link>
+      ))}
+
+      {initialPostsToShow < filteredPosts.length && (
+        <div className="text-center mt-6">
+          <button
+            onClick={() => setInitialPostsToShow(Infinity)}
+            className="bg-csred hover:bg-csred/80 text-white font-space-mono px-6 py-2  transition-all duration-200 hover:scale-105"
+          >
+            Show all {filteredPosts.length - initialPostsToShow} more minutes
+          </button>
+        </div>
+      )}
+    </div>
   )
 }
 
@@ -44,64 +160,114 @@ const MinutesList = ({
   posts: {
     slug: string
     content: string
+    date: string
+    title: string
   }[]
 }) => {
   const [searchQuery, setSearchQuery] = useState('')
   const [filteredPosts, setFilteredPosts] = useState(posts)
-  const [initialPostsToShow, setInitialPostsToShow] = useState(16)
+  const [initialPostsToShow, setInitialPostsToShow] = useState(20)
+  const [yearFilter, setYearFilter] = useState('')
+
+  const availableYears = Array.from(
+    new Set(posts.map((post) => post.date.split('-')[0]))
+  )
+    .sort()
+    .reverse()
 
   useEffect(() => {
-    setFilteredPosts(
-      posts.filter((post) =>
-        post.content.toLowerCase().includes(searchQuery.toLowerCase())
+    let filtered = posts
+
+    if (searchQuery) {
+      filtered = filtered.filter(
+        (post) =>
+          post.content.toLowerCase().includes(searchQuery.toLowerCase()) ||
+          post.slug.toLowerCase().includes(searchQuery.toLowerCase()) ||
+          post.date.includes(searchQuery)
       )
-    )
-  }, [searchQuery])
+    }
+
+    if (yearFilter) {
+      filtered = filtered.filter((post) => post.date.startsWith(yearFilter))
+    }
+
+    setFilteredPosts(filtered)
+  }, [searchQuery, yearFilter, posts])
 
   return (
-    <>
-      <div className="max-w-5xl mx-auto">
-        <div className="mb-10 mt-4">
-          <h1 className="font-tomorrow text-3xl">Minutes</h1>
-        </div>
-        <p className="text-md mb-10">
-          Welcome to the CompSoc Meeting Minutes Archive. Here, you will find
-          detailed records of all committee meetings dating back to 2016.
-          Explore these documents to gain insights into the decisions,
-          discussions, and developments that have shaped our society.
-        </p>
-
-        <SearchPosts setSearchQuery={setSearchQuery} />
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 lg:grid-cols-4">
-          {filteredPosts.slice(0, initialPostsToShow).map((post) => (
-            <MinuteFile key={post.slug} slug={post.slug} intro={post.content} />
-          ))}
-        </div>
-        {initialPostsToShow < filteredPosts.length && (
-          <button
-            onClick={() => setInitialPostsToShow(Infinity)}
-            className="text-primary font-space-mono bg-foreground px-3 py-2 rounded-sm m-auto block border border-border my-4"
-          >
-            Show all
-          </button>
-        )}
-        {filteredPosts.length === 0 && (
-          <div className="flex flex-col items-center justify-center space-y-4 mt-8 h-32">
-            <Image
-              src={`${prefix}/sad-mug.png`}
-              alt="No results"
-              width={150}
-              height={150}
-              className="m-auto my-0"
-            />
-
-            <p className="text-center font-space-mono text-lg mt-4">
-              Nothing to see here {':('}
-            </p>
-          </div>
-        )}
+    <div className="max-w-5xl mx-auto">
+      <div className="mb-10 mt-4">
+        <Heading title="Meeting Minutes" />
       </div>
-    </>
+      <p className="mt-6 font-space-mono mb-10">
+        Explore our comprehensive archive of committee meetings dating back to
+        2016. Discover the decisions, discussions, and developments that shaped
+        CompSoc.
+      </p>
+
+      <SearchBar
+        searchQuery={searchQuery}
+        setSearchQuery={setSearchQuery}
+        onFilterChange={setYearFilter}
+        yearFilter={yearFilter}
+        availableYears={availableYears}
+      />
+
+      {searchQuery || yearFilter ? (
+        <div className="mt-8">
+          <div className="flex items-center justify-between mb-6">
+            <h3 className="text-xl font-tomorrow">
+              {searchQuery ? 'Search Results' : `${yearFilter} Minutes`}
+              <span className="ml-2 text-sm font-space-mono text-zinc-400">
+                ({filteredPosts.length} found)
+              </span>
+            </h3>
+            {(searchQuery || yearFilter) && (
+              <button
+                onClick={() => {
+                  setSearchQuery('')
+                  setYearFilter('')
+                }}
+                className="text-sm text-csred hover:text-csred/80 font-space-mono"
+              >
+                Clear filters
+              </button>
+            )}
+          </div>
+          <ListView
+            filteredPosts={filteredPosts}
+            initialPostsToShow={initialPostsToShow}
+            setInitialPostsToShow={setInitialPostsToShow}
+          />
+        </div>
+      ) : (
+        <ListView
+          filteredPosts={filteredPosts}
+          initialPostsToShow={initialPostsToShow}
+          setInitialPostsToShow={setInitialPostsToShow}
+        />
+      )}
+
+      {filteredPosts.length === 0 && (searchQuery || yearFilter) && (
+        <div className="flex flex-col items-center justify-center py-16">
+          <div className="text-6xl mb-4">🔍</div>
+          <h3 className="text-xl font-tomorrow mb-2">No minutes found</h3>
+          <p className="text-zinc-400 text-center max-w-md">
+            Try adjusting your search terms or filters to find what you&apos;re
+            looking for.
+          </p>
+          <button
+            onClick={() => {
+              setSearchQuery('')
+              setYearFilter('')
+            }}
+            className="mt-4 px-6 py-2 bg-csred text-white  hover:bg-csred/80 transition-colors font-space-mono"
+          >
+            Clear all filters
+          </button>
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/app/minutes/[slug]/MinutesPage.tsx
+++ b/app/minutes/[slug]/MinutesPage.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { prefix } from '@/utils/prefix'
-import { DownloadCircle } from 'iconoir-react'
+import { ArrowLeft, Calendar, Download, ShareIos } from 'iconoir-react'
+import Link from 'next/link'
 
 const MinutesPage = ({
   contentHtml,
@@ -12,39 +13,134 @@ const MinutesPage = ({
   title: string
   modifiedAt: Date
 }) => {
+  const formatDate = (date: Date) => {
+    return date.toLocaleDateString('en-GB', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })
+  }
+
+  const handleShare = async () => {
+    if (navigator.share) {
+      await navigator.share({
+        title: `CompSoc Minutes - ${title}`,
+        url: window.location.href,
+      })
+    } else {
+      navigator.clipboard.writeText(window.location.href)
+    }
+  }
+
   return (
     <>
-      <div className="max-w-3xl mx-auto pt-24">
-        <p className="text-sm text-zinc-400">Meeting minutes</p>
-        <h1 className="font-tomorrow text-3xl text-left">{title}</h1>
+      <div className="min-h-screen bg-gradient-to-br from-background via-background to-csgrey/20">
+        <div className="max-w-4xl mx-auto pt-20 pb-16">
+          <div className="mb-12">
+            <div className="flex items-center gap-3 mb-6">
+              <Link
+                href={`${prefix}/minutes`}
+                className="flex items-center gap-2 text-zinc-400 hover:text-csred transition-colors font-space-mono text-sm group"
+              >
+                <ArrowLeft className="w-4 h-4 group-hover:-translate-x-1 transition-transform" />
+                Back to Minutes
+              </Link>
+              <span className="text-zinc-600">/</span>
+              <span className="text-zinc-400 font-space-mono text-sm">
+                {title}
+              </span>
+            </div>
 
-        <div
-          className="flex items-center justify-between bg-foreground border-border border-2 px-4 py-2 rounded-sm -mx-4 my-4"
-          style={{ width: 'calc(100% + 1rem)' }}
-        >
-          <p className="text-md text-zinc-400">
-            Last modified{' '}
-            {modifiedAt.toLocaleDateString('en-GB', {
-              day: '2-digit',
-              month: '2-digit',
-              year: 'numeric',
-            })}
-          </p>
-          {/* <button
-            className="flex items-center gap-2 hover:bg-background p-2 rounded-sm"
-            onClick={() => {
-              window.open(`${prefix}/minutes/${title}.md`, '_blank')
-            }}
-          >
-            <DownloadCircle />
-            Download
-            <span className="text-sm text-zinc-400">.md</span>
-          </button> */}
+            <div className="border border-border  bg-foreground/50 backdrop-blur-sm p-8">
+              <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-6">
+                <div className="flex-1">
+                  <p className="text-csred font-space-mono text-sm font-medium mb-2 uppercase tracking-wider">
+                    Meeting Minutes
+                  </p>
+                  <h1 className="font-tomorrow text-3xl lg:text-4xl mb-4 leading-tight">
+                    {formatDate(new Date(title))}
+                  </h1>
+
+                  <div className="flex flex-wrap gap-4 text-sm text-zinc-400">
+                    <div className="flex items-center gap-2">
+                      <Calendar className="w-4 h-4" />
+                      {formatDate(new Date(title))}
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Download className="w-4 h-4" />
+                      Last updated {modifiedAt.toLocaleDateString('en-GB')}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex gap-3">
+                  <button
+                    onClick={handleShare}
+                    className="flex items-center gap-2 px-4 py-2 bg-border hover:bg-border/70  transition-colors font-space-mono text-sm"
+                  >
+                    <ShareIos className="w-4 h-4" />
+                    Share
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="border border-border  bg-foreground/30 backdrop-blur-sm overflow-hidden">
+            <div className="p-8 lg:p-12">
+              <div
+                dangerouslySetInnerHTML={{ __html: contentHtml }}
+                className="minutes prose prose-invert prose-lg max-w-none
+                  prose-headings:font-tomorrow prose-headings:text-white prose-headings:border-b prose-headings:border-border/30 prose-headings:pb-3 prose-headings:mb-6
+                  prose-h1:text-2xl prose-h2:text-xl prose-h3:text-lg
+                  prose-p:leading-relaxed prose-p:text-zinc-300 prose-p:mb-4
+                  prose-li:text-zinc-300 prose-li:mb-2 prose-li:leading-relaxed
+                  prose-ul:space-y-2 prose-ol:space-y-2
+                  prose-strong:text-white prose-strong:font-semibold
+                  prose-em:text-zinc-200 prose-em:italic
+                  prose-code:bg-border/50 prose-code:px-2 prose-code:py-1 prose-code:rounded prose-code:text-csred prose-code:text-sm
+                  prose-blockquote:border-l-4 prose-blockquote:border-csred prose-blockquote:bg-border/20 prose-blockquote:p-4 prose-blockquote:rounded-r-lg prose-blockquote:not-italic
+                  prose-a:text-csred prose-a:no-underline hover:prose-a:underline hover:prose-a:text-csred/80
+                  prose-hr:border-border/50 prose-hr:my-8
+                "
+              />
+            </div>
+          </div>
+
+          <div className="mt-12 pt-8 border-t border-border/30">
+            <div className="flex flex-col sm:flex-row justify-between items-center gap-4 text-sm text-zinc-400">
+              <div>
+                <p>CompSoc Edinburgh • Committee Meeting Minutes</p>
+                <p>
+                  Last modified on{' '}
+                  {modifiedAt.toLocaleDateString('en-GB', {
+                    weekday: 'long',
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                  })}
+                </p>
+              </div>
+              <div className="flex gap-4">
+                <Link
+                  href={`${prefix}/minutes`}
+                  className="hover:text-csred transition-colors"
+                >
+                  Browse all minutes
+                </Link>
+                <button
+                  onClick={() =>
+                    window.scrollTo({ top: 0, behavior: 'smooth' })
+                  }
+                  className="hover:text-csred transition-colors"
+                >
+                  Back to top
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
-        <div
-          dangerouslySetInnerHTML={{ __html: contentHtml }}
-          className="minutes prose prose-invert"
-        />
       </div>
     </>
   )

--- a/app/minutes/[slug]/styles.css
+++ b/app/minutes/[slug]/styles.css
@@ -1,9 +1,201 @@
-.minutes li {
-  margin-left: 12px;
-  list-style-type: circle;
+.minutes {
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    'Helvetica Neue',
+    Arial,
+    'Noto Sans',
+    sans-serif;
+  line-height: 1.7;
+}
+
+.minutes h1 {
+  font-size: 2.25rem;
+  font-weight: 700;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+  color: #ffffff;
+  border-bottom: 2px solid #484848;
+  padding-bottom: 0.75rem;
 }
 
 .minutes h2 {
-  font-size: 1.5em;
-  margin-top: 24px;
+  font-size: 1.875rem;
+  font-weight: 600;
+  margin-top: 2.5rem;
+  margin-bottom: 1rem;
+  color: #ffffff;
+  border-bottom: 1px solid #484848;
+  padding-bottom: 0.5rem;
+}
+
+.minutes h3 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+  color: #ffffff;
+}
+
+.minutes h4,
+.minutes h5,
+.minutes h6 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+  color: #ffffff;
+}
+
+.minutes p {
+  margin-bottom: 1.25rem;
+  color: #d4d4d8;
+  font-size: 1rem;
+}
+
+.minutes ul,
+.minutes ol {
+  margin-bottom: 1.5rem;
+  padding-left: 1.5rem;
+}
+
+.minutes li {
+  margin-bottom: 0.75rem;
+  color: #d4d4d8;
+  line-height: 1.7;
+  list-style-type: disc;
+}
+
+.minutes ol li {
+  list-style-type: decimal;
+}
+
+.minutes li::marker {
+  color: #ce3234;
+}
+
+.minutes strong,
+.minutes b {
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.minutes em,
+.minutes i {
+  font-style: italic;
+  color: #e4e4e7;
+}
+
+.minutes code {
+  background-color: rgba(72, 72, 72, 0.5);
+  color: #ce3234;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Consolas,
+    'Liberation Mono', Menlo, monospace;
+}
+
+.minutes pre {
+  background-color: #353535;
+  border: 1px solid #484848;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  margin: 1.5rem 0;
+  overflow-x: auto;
+}
+
+.minutes pre code {
+  background-color: transparent;
+  color: #d4d4d8;
+  padding: 0;
+}
+
+.minutes blockquote {
+  border-left: 4px solid #ce3234;
+  background-color: rgba(72, 72, 72, 0.2);
+  padding: 1rem;
+  margin: 1.5rem 0;
+  border-radius: 0 0.5rem 0.5rem 0;
+  font-style: normal;
+}
+
+.minutes blockquote p {
+  margin-bottom: 0;
+  color: #e4e4e7;
+}
+
+.minutes a {
+  color: #ce3234;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.minutes a:hover {
+  color: rgba(206, 50, 52, 0.8);
+  text-decoration: underline;
+}
+
+.minutes hr {
+  border: none;
+  height: 1px;
+  background-color: rgba(72, 72, 72, 0.5);
+  margin: 2rem 0;
+}
+
+.minutes table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  border: 1px solid #484848;
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+.minutes th,
+.minutes td {
+  padding: 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #484848;
+}
+
+.minutes th {
+  background-color: #353535;
+  font-weight: 600;
+  color: #ffffff;
+}
+
+.minutes td {
+  color: #d4d4d8;
+}
+
+.minutes tbody tr:hover {
+  background-color: rgba(72, 72, 72, 0.2);
+}
+
+.minutes ul ul {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.minutes ul ul li {
+  list-style-type: circle;
+  margin-bottom: 0.5rem;
+}
+
+.minutes ul ul ul li {
+  list-style-type: square;
+  margin-bottom: 0.25rem;
+}
+
+.minutes li p {
+  margin-bottom: 0.5rem;
+}
+
+.minutes li:last-child {
+  margin-bottom: 0;
 }

--- a/app/news/NewsList.tsx
+++ b/app/news/NewsList.tsx
@@ -1,51 +1,157 @@
 'use client'
 
 import Heading from '@/components/heading'
-import SearchPosts from '@/components/SearchPosts'
 import { prefix } from '@/utils/prefix'
-import Image from 'next/image'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
+import { Search, Filter, X } from 'iconoir-react'
 
-const NewsFile = ({
-  slug,
-  intro,
-  title,
-  date,
+const SearchBar = ({
+  searchQuery,
+  setSearchQuery,
+  onFilterChange,
+  yearFilter,
+  availableYears,
 }: {
-  slug: string
-  intro: string
-  title: string
-  date: string
+  searchQuery: string
+  setSearchQuery: (query: string) => void
+  onFilterChange: (year: string) => void
+  yearFilter: string
+  availableYears: string[]
+}) => {
+  const [showFilters, setShowFilters] = useState(false)
+
+  return (
+    <div className="mb-8">
+      <div className="relative flex flex-col sm:flex-row gap-4 items-center">
+        <div className="relative flex-1 max-w-md">
+          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-zinc-400 w-5 h-5" />
+          <input
+            type="text"
+            placeholder="Search news, topics, or dates..."
+            className="w-full pl-10 pr-4 py-3 bg-foreground border border-border  focus:outline-none focus:ring-2 focus:ring-csred/50 focus:border-csred transition-all duration-200 font-space-mono text-sm"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+          />
+          {searchQuery && (
+            <button
+              onClick={() => setSearchQuery('')}
+              className="absolute right-3 top-1/2 transform -translate-y-1/2 text-zinc-400 hover:text-white transition-colors"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          )}
+        </div>
+
+        <button
+          onClick={() => setShowFilters(!showFilters)}
+          className="flex items-center gap-2 px-4 py-3 bg-foreground border border-border  hover:bg-border/50 transition-colors font-space-mono text-sm"
+        >
+          <Filter className="w-4 h-4" />
+          Filters
+          {yearFilter && (
+            <span className="bg-csred text-white px-2 py-1 rounded-full text-xs">
+              {yearFilter}
+            </span>
+          )}
+        </button>
+      </div>
+
+      {showFilters && (
+        <div className="mt-4 p-4 bg-foreground border border-border ">
+          <div className="flex flex-wrap gap-2">
+            <button
+              onClick={() => onFilterChange('')}
+              className={`px-3 py-2  text-sm font-space-mono transition-colors ${
+                !yearFilter
+                  ? 'bg-csred text-white'
+                  : 'bg-border text-zinc-300 hover:bg-border/70'
+              }`}
+            >
+              All Years
+            </button>
+            {availableYears.map((year) => (
+              <button
+                key={year}
+                onClick={() => onFilterChange(year)}
+                className={`px-3 py-2  text-sm font-space-mono transition-colors ${
+                  yearFilter === year
+                    ? 'bg-csred text-white'
+                    : 'bg-border text-zinc-300 hover:bg-border/70'
+                }`}
+              >
+                {year}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+const ListView = ({
+  filteredPosts,
+  initialPostsToShow,
+  setInitialPostsToShow,
+}: {
+  filteredPosts: {
+    slug: string
+    content: string
+    date: string
+    title: string
+  }[]
+  initialPostsToShow: number
+  setInitialPostsToShow: (count: number) => void
 }) => {
   return (
-    <Link href={`${prefix}/news/${slug}`}>
-      <div className="border border-border p-4 rounded-sm bg-foreground">
-        <h2 className="text-xl font-space-mono">
-          {title.length > 30 ? `${title.slice(0, 27)}...` : title}
-        </h2>
-        <p
-          style={{
-            display: '-webkit-box',
-            WebkitLineClamp: 5,
-            WebkitBoxOrient: 'vertical',
-            overflow: 'hidden',
-            position: 'relative',
-          }}
-        >
-          <span className="opacity-70">{date}</span>
-          <span
-            style={{
-              position: 'absolute',
-              bottom: 0,
-              left: 0,
-              right: 0,
-              height: '10em',
-            }}
-          />
-        </p>
-      </div>
-    </Link>
+    <div>
+      {filteredPosts.slice(0, initialPostsToShow).map((post, index) => (
+        <Link key={post.slug} href={`${prefix}/news/${post.slug}`}>
+          <div className="group mt-4 border border-border p-4  bg-foreground hover:bg-border/30 transition-all duration-200 hover:scale-[1.01]">
+            <div className="flex items-center justify-between">
+              <div className="flex-1">
+                <h3 className="text-lg font-tomorrow text-white group-hover:text-csred transition-colors">
+                  {post.title.length > 50
+                    ? `${post.title.slice(0, 47)}...`
+                    : post.title}
+                </h3>
+                <span className="text-sm text-zinc-400 font-space-mono">
+                  {new Date(post.date).toLocaleDateString('en-GB', {
+                    weekday: 'long',
+                    day: 'numeric',
+                    month: 'short',
+                    year: 'numeric',
+                  })}
+                </span>
+              </div>
+            </div>
+            <p
+              className="text-sm opacity-70 leading-relaxed mt-2"
+              style={{
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+              }}
+            >
+              {post.content.slice(0, 180)}...
+            </p>
+          </div>
+        </Link>
+      ))}
+
+      {initialPostsToShow < filteredPosts.length && (
+        <div className="text-center mt-6">
+          <button
+            onClick={() => setInitialPostsToShow(Infinity)}
+            className="bg-csred hover:bg-csred/80 text-white font-space-mono px-6 py-2  transition-all duration-200 hover:scale-105"
+          >
+            Show all {filteredPosts.length - initialPostsToShow} more news
+          </button>
+        </div>
+      )}
+    </div>
   )
 }
 
@@ -61,65 +167,108 @@ const NewsList = ({
 }) => {
   const [searchQuery, setSearchQuery] = useState('')
   const [filteredPosts, setFilteredPosts] = useState(posts)
-  const [initialPostsToShow, setInitialPostsToShow] = useState(16)
+  const [initialPostsToShow, setInitialPostsToShow] = useState(20)
+  const [yearFilter, setYearFilter] = useState('')
+
+  const availableYears = Array.from(
+    new Set(posts.map((post) => post.date.split('-')[0]))
+  )
+    .sort()
+    .reverse()
 
   useEffect(() => {
-    setFilteredPosts(
-      posts.filter((post) =>
-        post.content.toLowerCase().includes(searchQuery.toLowerCase())
+    let filtered = posts
+
+    if (searchQuery) {
+      filtered = filtered.filter(
+        (post) =>
+          post.content.toLowerCase().includes(searchQuery.toLowerCase()) ||
+          post.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+          post.date.includes(searchQuery)
       )
-    )
-  }, [posts, searchQuery])
+    }
+
+    if (yearFilter) {
+      filtered = filtered.filter((post) => post.date.startsWith(yearFilter))
+    }
+
+    setFilteredPosts(filtered)
+  }, [searchQuery, yearFilter, posts])
 
   return (
-    <>
-      <div className="max-w-5xl mx-auto">
-        <div className="mb-10 mt-4">
-          <Heading title="News" />
-        </div>
-        <p className="text-md mb-10">
-          Welcome to the CompSoc news page! Here, you&apos;ll find an archive of
-          all the essential updates, including manifestos from our past AGMs and
-          EGMs.
-        </p>
-
-        <SearchPosts setSearchQuery={setSearchQuery} />
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 lg:grid-cols-4">
-          {filteredPosts.slice(0, initialPostsToShow).map((post) => (
-            <NewsFile
-              key={post.slug}
-              slug={post.slug}
-              intro={post.content}
-              title={post.title}
-              date={post.date}
-            />
-          ))}
-        </div>
-        {initialPostsToShow < filteredPosts.length && (
-          <button
-            onClick={() => setInitialPostsToShow(Infinity)}
-            className="text-primary font-space-mono bg-foreground px-3 py-2 rounded-sm m-auto block border border-border my-4"
-          >
-            Show all
-          </button>
-        )}
-        {filteredPosts.length === 0 && (
-          <div className="flex flex-col items-center justify-center space-y-4 mt-8 h-32">
-            <Image
-              src={`${prefix}/sad-mug.png`}
-              alt="No results"
-              width={150}
-              height={150}
-              className="m-auto my-0"
-            />
-
-            <p className="text-center font-space-mono text-lg mt-4">
-              Nothing to see here {':('}
-            </p>
-          </div>
-        )}
+    <div className="max-w-5xl mx-auto">
+      <div className="mb-10 mt-4">
+        <Heading title="News" />
       </div>
-    </>
+      <p className="mt-6 font-space-mono mb-10">
+        Welcome to the CompSoc news page! Here, you&apos;ll find an archive of
+        all the essential updates, including manifestos from our past AGMs and
+        EGMs.
+      </p>
+
+      <SearchBar
+        searchQuery={searchQuery}
+        setSearchQuery={setSearchQuery}
+        onFilterChange={setYearFilter}
+        yearFilter={yearFilter}
+        availableYears={availableYears}
+      />
+
+      {searchQuery || yearFilter ? (
+        <div className="mt-8">
+          <div className="flex items-center justify-between mb-6">
+            <h3 className="text-xl font-tomorrow">
+              {searchQuery ? 'Search Results' : `${yearFilter} News`}
+              <span className="ml-2 text-sm font-space-mono text-zinc-400">
+                ({filteredPosts.length} found)
+              </span>
+            </h3>
+            {(searchQuery || yearFilter) && (
+              <button
+                onClick={() => {
+                  setSearchQuery('')
+                  setYearFilter('')
+                }}
+                className="text-sm text-csred hover:text-csred/80 font-space-mono"
+              >
+                Clear filters
+              </button>
+            )}
+          </div>
+          <ListView
+            filteredPosts={filteredPosts}
+            initialPostsToShow={initialPostsToShow}
+            setInitialPostsToShow={setInitialPostsToShow}
+          />
+        </div>
+      ) : (
+        <ListView
+          filteredPosts={filteredPosts}
+          initialPostsToShow={initialPostsToShow}
+          setInitialPostsToShow={setInitialPostsToShow}
+        />
+      )}
+
+      {filteredPosts.length === 0 && (searchQuery || yearFilter) && (
+        <div className="flex flex-col items-center justify-center py-16">
+          <div className="text-6xl mb-4">🔍</div>
+          <h3 className="text-xl font-tomorrow mb-2">No news found</h3>
+          <p className="text-zinc-400 text-center max-w-md">
+            Try adjusting your search terms or filters to find what you&apos;re
+            looking for.
+          </p>
+          <button
+            onClick={() => {
+              setSearchQuery('')
+              setYearFilter('')
+            }}
+            className="mt-4 px-6 py-2 bg-csred text-white  hover:bg-csred/80 transition-colors font-space-mono"
+          >
+            Clear all filters
+          </button>
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/app/news/[slug]/NewsPage.tsx
+++ b/app/news/[slug]/NewsPage.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { prefix } from '@/utils/prefix'
-import { DownloadCircle } from 'iconoir-react'
+import { ArrowLeft, Calendar, ShareIos } from 'iconoir-react'
+import Link from 'next/link'
 
 const NewsPage = ({
   contentHtml,
@@ -12,39 +13,130 @@ const NewsPage = ({
   title: string
   modifiedAt: Date
 }) => {
+  const formatDate = (date: Date) => {
+    return date.toLocaleDateString('en-GB', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })
+  }
+
+  const handleShare = async () => {
+    if (navigator.share) {
+      await navigator.share({
+        title: `CompSoc News - ${title}`,
+        url: window.location.href,
+      })
+    } else {
+      navigator.clipboard.writeText(window.location.href)
+    }
+  }
+
   return (
     <>
-      <div className="max-w-3xl mx-auto pt-24">
-        <p className="text-sm text-zinc-400">News</p>
-        <h1 className="font-tomorrow text-3xl text-left">{title}</h1>
+      <div className="min-h-screen bg-gradient-to-br from-background via-background to-csgrey/20">
+        <div className="max-w-4xl mx-auto pt-20 pb-16">
+          <div className="mb-12">
+            <div className="flex items-center gap-3 mb-6">
+              <Link
+                href={`${prefix}/news`}
+                className="flex items-center gap-2 text-zinc-400 hover:text-csred transition-colors font-space-mono text-sm group"
+              >
+                <ArrowLeft className="w-4 h-4 group-hover:-translate-x-1 transition-transform" />
+                Back to News
+              </Link>
+              <span className="text-zinc-600">/</span>
+              <span className="text-zinc-400 font-space-mono text-sm">
+                {title}
+              </span>
+            </div>
 
-        <div
-          className="flex items-center justify-between bg-foreground border-border border-2 px-4 py-2 rounded-sm -mx-4 my-4"
-          style={{ width: 'calc(100% + 1rem)' }}
-        >
-          <p className="text-md text-zinc-400">
-            Last modified{' '}
-            {modifiedAt.toLocaleDateString('en-GB', {
-              day: '2-digit',
-              month: '2-digit',
-              year: 'numeric',
-            })}
-          </p>
-          {/* <button
-            className="flex items-center gap-2 hover:bg-background p-2 rounded-sm"
-            onClick={() => {
-              window.open(`${prefix}/news/${title}.md`, '_blank')
-            }}
-          >
-            <DownloadCircle />
-            Download
-            <span className="text-sm text-zinc-400">.md</span>
-          </button> */}
+            <div className="border border-border  bg-foreground/50 backdrop-blur-sm p-8">
+              <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-6">
+                <div className="flex-1">
+                  <p className="text-csred font-space-mono text-sm font-medium mb-2 uppercase tracking-wider">
+                    News Article
+                  </p>
+                  <h1 className="font-tomorrow text-3xl lg:text-4xl mb-4 leading-tight">
+                    {title}
+                  </h1>
+
+                  <div className="flex flex-wrap gap-4 text-sm text-zinc-400">
+                    <div className="flex items-center gap-2">
+                      <Calendar className="w-4 h-4" />
+                      {formatDate(modifiedAt)}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex gap-3">
+                  <button
+                    onClick={handleShare}
+                    className="flex items-center gap-2 px-4 py-2 bg-border hover:bg-border/70  transition-colors font-space-mono text-sm"
+                  >
+                    <ShareIos className="w-4 h-4" />
+                    Share
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="border border-border  bg-foreground/30 backdrop-blur-sm overflow-hidden">
+            <div className="p-8 lg:p-12">
+              <div
+                dangerouslySetInnerHTML={{ __html: contentHtml }}
+                className="news prose prose-invert prose-lg max-w-none
+                  prose-headings:font-tomorrow prose-headings:text-white prose-headings:border-b prose-headings:border-border/30 prose-headings:pb-3 prose-headings:mb-6
+                  prose-h1:text-2xl prose-h2:text-xl prose-h3:text-lg
+                  prose-p:leading-relaxed prose-p:text-zinc-300 prose-p:mb-4
+                  prose-li:text-zinc-300 prose-li:mb-2 prose-li:leading-relaxed
+                  prose-ul:space-y-2 prose-ol:space-y-2
+                  prose-strong:text-white prose-strong:font-semibold
+                  prose-em:text-zinc-200 prose-em:italic
+                  prose-code:bg-border/50 prose-code:px-2 prose-code:py-1 prose-code:rounded prose-code:text-csred prose-code:text-sm
+                  prose-blockquote:border-l-4 prose-blockquote:border-csred prose-blockquote:bg-border/20 prose-blockquote:p-4 prose-blockquote:rounded-r-lg prose-blockquote:not-italic
+                  prose-a:text-csred prose-a:no-underline hover:prose-a:underline hover:prose-a:text-csred/80
+                  prose-hr:border-border/50 prose-hr:my-8
+                "
+              />
+            </div>
+          </div>
+
+          <div className="mt-12 pt-8 border-t border-border/30">
+            <div className="flex flex-col sm:flex-row justify-between items-center gap-4 text-sm text-zinc-400">
+              <div>
+                <p>CompSoc Edinburgh • News & Updates</p>
+                <p>
+                  Published on{' '}
+                  {modifiedAt.toLocaleDateString('en-GB', {
+                    weekday: 'long',
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                  })}
+                </p>
+              </div>
+              <div className="flex gap-4">
+                <Link
+                  href={`${prefix}/news`}
+                  className="hover:text-csred transition-colors"
+                >
+                  Browse all news
+                </Link>
+                <button
+                  onClick={() =>
+                    window.scrollTo({ top: 0, behavior: 'smooth' })
+                  }
+                  className="hover:text-csred transition-colors"
+                >
+                  Back to top
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
-        <div
-          dangerouslySetInnerHTML={{ __html: contentHtml }}
-          className="news prose prose-invert"
-        />
       </div>
     </>
   )

--- a/app/news/[slug]/page.tsx
+++ b/app/news/[slug]/page.tsx
@@ -21,17 +21,14 @@ export async function generateStaticParams() {
   }))
 }
 
-// Multiple versions of this page will be statically generated
 export default async function Page({ params }: { params: { slug: string } }) {
   const { slug } = params
-  // Read markdown file as string
   const postDirectory = path.join(__dirname, '../../../../../constants/news')
   const filePath = path.join(postDirectory, `${slug}.md`)
   const fileContents = fs.readFileSync(filePath, 'utf8')
 
-  // Extract front matter and content using gray-matter
   const { data, content } = matter(fileContents)
-  const title = data.title as string // Extract the title from the front matter
+  const title = data.title as string
 
   const fileStats = fs.statSync(filePath)
   const modifiedAt = new Date(fileStats.mtime)

--- a/app/news/[slug]/styles.css
+++ b/app/news/[slug]/styles.css
@@ -1,9 +1,201 @@
-.minutes li {
-  margin-left: 12px;
-  list-style-type: circle;
+.news {
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    'Helvetica Neue',
+    Arial,
+    'Noto Sans',
+    sans-serif;
+  line-height: 1.7;
 }
 
-.minutes h2 {
-  font-size: 1.5em;
-  margin-top: 24px;
+.news h1 {
+  font-size: 2.25rem;
+  font-weight: 700;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+  color: #ffffff;
+  border-bottom: 2px solid #484848;
+  padding-bottom: 0.75rem;
+}
+
+.news h2 {
+  font-size: 1.875rem;
+  font-weight: 600;
+  margin-top: 2.5rem;
+  margin-bottom: 1rem;
+  color: #ffffff;
+  border-bottom: 1px solid #484848;
+  padding-bottom: 0.5rem;
+}
+
+.news h3 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+  color: #ffffff;
+}
+
+.news h4,
+.news h5,
+.news h6 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+  color: #ffffff;
+}
+
+.news p {
+  margin-bottom: 1.25rem;
+  color: #d4d4d8;
+  font-size: 1rem;
+}
+
+.news ul,
+.news ol {
+  margin-bottom: 1.5rem;
+  padding-left: 1.5rem;
+}
+
+.news li {
+  margin-bottom: 0.75rem;
+  color: #d4d4d8;
+  line-height: 1.7;
+  list-style-type: disc;
+}
+
+.news ol li {
+  list-style-type: decimal;
+}
+
+.news li::marker {
+  color: #ce3234;
+}
+
+.news strong,
+.news b {
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.news em,
+.news i {
+  font-style: italic;
+  color: #e4e4e7;
+}
+
+.news code {
+  background-color: rgba(72, 72, 72, 0.5);
+  color: #ce3234;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Consolas,
+    'Liberation Mono', Menlo, monospace;
+}
+
+.news pre {
+  background-color: #353535;
+  border: 1px solid #484848;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  margin: 1.5rem 0;
+  overflow-x: auto;
+}
+
+.news pre code {
+  background-color: transparent;
+  color: #d4d4d8;
+  padding: 0;
+}
+
+.news blockquote {
+  border-left: 4px solid #ce3234;
+  background-color: rgba(72, 72, 72, 0.2);
+  padding: 1rem;
+  margin: 1.5rem 0;
+  border-radius: 0 0.5rem 0.5rem 0;
+  font-style: normal;
+}
+
+.news blockquote p {
+  margin-bottom: 0;
+  color: #e4e4e7;
+}
+
+.news a {
+  color: #ce3234;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.news a:hover {
+  color: rgba(206, 50, 52, 0.8);
+  text-decoration: underline;
+}
+
+.news hr {
+  border: none;
+  height: 1px;
+  background-color: rgba(72, 72, 72, 0.5);
+  margin: 2rem 0;
+}
+
+.news table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  border: 1px solid #484848;
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+.news th,
+.news td {
+  padding: 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #484848;
+}
+
+.news th {
+  background-color: #353535;
+  font-weight: 600;
+  color: #ffffff;
+}
+
+.news td {
+  color: #d4d4d8;
+}
+
+.news tbody tr:hover {
+  background-color: rgba(72, 72, 72, 0.2);
+}
+
+.news ul ul {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.news ul ul li {
+  list-style-type: circle;
+  margin-bottom: 0.5rem;
+}
+
+.news ul ul ul li {
+  list-style-type: square;
+  margin-bottom: 0.25rem;
+}
+
+.news li p {
+  margin-bottom: 0.5rem;
+}
+
+.news li:last-child {
+  margin-bottom: 0;
 }

--- a/constants/minutes/2024-07-28.md
+++ b/constants/minutes/2024-07-28.md
@@ -3,6 +3,7 @@ date: 28/07/2024 20:30
 ---
 
 ## **Attendees:**
+
 - Vincent
 - Godfrey
 - Agam
@@ -16,41 +17,47 @@ date: 28/07/2024 20:30
 ## **Agenda:** Academic Families Meeting
 
 ## 1. **Opening Remarks**
+
 - The meeting started with an overview of academic families.
 - Committee to find 3 people each who would want to be academic parents
 
 ## 2. **Promotional Material**
+
 - Inquiry about participant sign-ups.
 - Instagram, LinkedIn, and email + others will be used for promotional content.
 - The event will be joint with the school, making it more official and allowing more people to attend.
 
 ## 3. **Discussion on Incentives**
+
 - Suggestion that parents could receive free coffee from EUSA.
 - Discussion on the need for more incentives to attract 4th-year and master's students, such as forum access for parents.
 - Concerns about the inclusivity of EDI (Equality, Diversity, and Inclusion) questions in the form; currently, only male or female options are asked.
 
 ## 4. **First Families Event**
+
 - Review of a document detailing the first families event.
-    - Venue ideas discussed, with weekends being preferred for a more fun atmosphere.
-    - Decision on the pub crawl will depend on participant turnout on the day.
-    - Suggestion to include the time commitment in the sign-up form so participants know the weekly involvement required.
-    - Promotion should detail the number and frequency of events.
-    - Ideas like creating traditions, structured activities, and competitions between families were discussed.
-    - Proposal for a family flag or crest.
+  - Venue ideas discussed, with weekends being preferred for a more fun atmosphere.
+  - Decision on the pub crawl will depend on participant turnout on the day.
+  - Suggestion to include the time commitment in the sign-up form so participants know the weekly involvement required.
+  - Promotion should detail the number and frequency of events.
+  - Ideas like creating traditions, structured activities, and competitions between families were discussed.
+  - Proposal for a family flag or crest.
 - **Participation Numbers**
-    - Expected numbers: 250 children, 50 parents, plus committee and staff.
+  - Expected numbers: 250 children, 50 parents, plus committee and staff.
 - **Student Satisfaction and Event Ideas**
-    - Inquiry about thoughts on student satisfaction.
-    - Suggestion to bring back beer pong with lecturers.
-    - Proposal for sessions with parents and faculty to discuss student experience.
-    - Concerns raised about using the Informatics Forum as the default venue due to its atmosphere.
-    - Alternative venues such as The Caves and Pollock Place mentioned, with catering constraints noted for The Caves.
-    - Funding details: a minimum of £5,000 from the school is guaranteed, with the possibility of more.
+  - Inquiry about thoughts on student satisfaction.
+  - Suggestion to bring back beer pong with lecturers.
+  - Proposal for sessions with parents and faculty to discuss student experience.
+  - Concerns raised about using the Informatics Forum as the default venue due to its atmosphere.
+  - Alternative venues such as The Caves and Pollock Place mentioned, with catering constraints noted for The Caves.
+  - Funding details: a minimum of £5,000 from the school is guaranteed, with the possibility of more.
 
 ## 5. **Pitchathon**
+
 - A weekend event where students form teams to develop startup ideas.
 - Students work with mentors and present their ideas to a sponsor panel, with potential funding opportunities.
 - The event aims to help students develop soft skills and enhance networking.
 
 ## 6. **Action Items**
+
 - Committee to find 3 people each to sign up to be academic parents.

--- a/constants/minutes/2024-09-15.md
+++ b/constants/minutes/2024-09-15.md
@@ -3,6 +3,7 @@ date: 15/09/2024 12:00
 ---
 
 ## **Attendees:**
+
 - Vincent
 - Godfrey
 - Elisa
@@ -25,6 +26,7 @@ date: 15/09/2024 12:00
 ## **Agenda:** Braistorming Session
 
 ## 1. **Why did we join CompSoc?**
+
 - Share passions (3 votes)
 - Practice working in a business environment (5 votes)
 - Expand horizons and do new things (5 votes)
@@ -40,6 +42,7 @@ date: 15/09/2024 12:00
 - Pizza (1 vote)
 
 ## 2. **Main Ideas**
+
 1. Meeting people
 2. Organising events (help younger students gain skills, more people, increase funds, reach the level of ETH Zurich, Hexacon (technical events), Rentech (quant firm), IC Hack, EPFL)
 3. Practise for the business environment
@@ -47,6 +50,7 @@ date: 15/09/2024 12:00
 5. Grow community
 
 ## 3. **What does CompSoc solve?**
+
 - We solve the problem of a lack of community (in terms of meeting people and technical learning).
 - Filling in education that uni doesn’t cover.
 - We create connections with the industry through sponsors at events and graduate network.
@@ -54,11 +58,13 @@ date: 15/09/2024 12:00
 - We make events less intimidating (create teams for stuff to create a space for technical and new people, get the committee to talk to other people).
 
 ## 4. **Why is CompSoc effective?**
+
 - We have a high attendance
 - People have gotten jobs through compsoc
 - Sponsors give us money so we bring them value (attendees at events, applications, show success)
 
 ## 5. **Welcome Week Recap**
+
 - Arthurs's seat hike was successful with about 80 people showing up.
 - The pub crawl and brunch went well.
 - Could’ve used more communication for transparency with who is running certain things.
@@ -66,16 +72,19 @@ date: 15/09/2024 12:00
 - We need to use a centralised Google Drive for the use of committee planning to make sure info is correct and easy to find. Make sure there is a single source of truth.
 
 ## 6. **How to use Year Reps**
+
 - Use year reps during compulsory courses to make announcements about CompSoc.
 - Message lecturers to get a QR code on the first lecture slide.
 
 ## 7. **School of Informatics Discussion**
+
 - We can help the school by improving student satisfaction.
 - Do surveys on student satisfaction.
 - Implement experiential learning?
 - Ask for a joint room with Infpals.
 
 ## 8. **Metrics to be Tracked**
+
 - Instagram metrics.
 - Attendance at events.
 - Survey responses (write survey soon).
@@ -83,4 +92,5 @@ date: 15/09/2024 12:00
 - Units of merch sold.
 
 ## 9. **Action Items**
+
 - Write a survey to be given out.

--- a/constants/minutes/2024-09-19.md
+++ b/constants/minutes/2024-09-19.md
@@ -3,6 +3,7 @@ date: 19/09/2024 16:30
 ---
 
 ## **Attendees:**
+
 - Vincent
 - Godfrey (Online)
 - Elisa (Online)
@@ -19,17 +20,20 @@ date: 19/09/2024 16:30
 - Leo
 
 ## 1. **Academic Families**
+
 - First event is planned for the 25-26th September.
 - The plans and details of the event are shared.
 - Plans for food are to go to Costco and get food delivered.
 - We will be organising icebreaker games such as mini pub quiz and others.
 
 ## 2. **G-Research Event**
+
 - CompSoc will do the promotion for the event.
 - G-Research will do the financing for the event.
 - Debate about pizzas and packages for bespoke events at each level.
 
 ## 3. **STMU**
+
 - Details, dates, speakers and exhibitions were discussed.
 - EGM:
   - Elections for the committee positions (VP, First Year Rep, Junior Treasurer).
@@ -42,18 +46,21 @@ date: 19/09/2024 16:30
   - 2nd years can do the order prediction for their data science project.
 
 ## 4. **Adahack**
+
 - Event is on the 19th of October.
 - We will host our own workshop and use CompSoc merch as prizes.
 - Host a challenge and market it as an entrepreneurial challenge.
 - Use Adahack to promote and test out HTB.
 
 ## 5. **Junior treasurer**
+
 - Elisa proposed a new role for a Junior Treasurer.
 - The role will be voted on at the EMG with First Year Rep.
 - The hope is that this person becomes treasurer the year after.
 - This will be put to vote after the meeting.
 
 ## 6. **Action items**
+
 - Post on everywhere for SIG fair and G-Research event.
 - Fergus come up with challenges for Adahack.
 - Check how long it takes to print quarter zips.

--- a/constants/minutes/2024-09-27.md
+++ b/constants/minutes/2024-09-27.md
@@ -3,6 +3,7 @@ date: 27/09/2024 16:00
 ---
 
 ## **Attendees:**
+
 - Vincent
 - Godfrey
 - Elisa
@@ -20,6 +21,7 @@ date: 27/09/2024 16:00
 - Cat
 
 ## 1. **HackTheBurgh**
+
 - Futures Institute idea for venue so Godfrey will email and ask them.
   - It has a higher capacity than the Nucleus so could expand HTB to more people.
   - It is also a very new and nice venue so would be interesting.
@@ -35,6 +37,7 @@ date: 27/09/2024 16:00
   - Idea to increase friction to getting reimnursements (emailing) so only people who need them will email.
 
 ## 2. **Academic Families Debrief**
+
 - Feedback from the event was very postitive.
   - Fiona and the cohorts were very impressed and happy.
   - Roughly 100 attendees each night.
@@ -50,10 +53,12 @@ date: 27/09/2024 16:00
 - Anastasia to make a forecast for AcFams spending based on budget of 5k.
 
 ## 3. **Junior Treasurer Vote results**
+
 - Vote for the Junior Treasurer role to be added passed unanimously.
 - We met the quorum reqired for core committee and executives to vote.
 
 ## 4. **SIG Fair Debrief**
+
 - The Fair went well, good attendance, engaging speeches, and raised awareness of SIGs.
 - Raffle was effective fundraising.
 - The poster boards were bad an ineffective.
@@ -63,6 +68,7 @@ date: 27/09/2024 16:00
 - Idea to get food other than pizza like biscuits and crisps.
 
 ## 5. **G-Research Event Update**
+
 - The event is 7th October 18:00 to 21:30.
 - Setup starts at 17:00
 - Godfrey to follow up on servitor cover.
@@ -70,6 +76,7 @@ date: 27/09/2024 16:00
 - Agam to post a story to remind people.
 
 ## 6. **AdaHack Discussion**
+
 - Event is on 19th of October.
 - We do 1 challenge and 1 mini-game.
 - Give out CompSoc prizes to the winners.
@@ -78,15 +85,18 @@ date: 27/09/2024 16:00
 - Have 4-5 people there for judging the challenge.
 
 ## 7. **Workshop Discussion/Follow-Up**
+
 - Try to implement the things discussed in the workshop.
 - Celebrate out achievements (Hitting 1000 followers on Insta)
 - Allocate time at the start or end of meetings to talk about the things that went well.
 
 ## 8. **Ping-Pong Table**
+
 - Marton got ghosted when asking about this.
 - Cat will pick this up.
 
 ## 9. **Miscellaneous**
+
 - Checks if everyone can see the CompSoc Internal Calendar, not many seem to have access.
 - Meetings will be kept in the calendar.
 - Use Staff Forums for themed discussions.
@@ -95,6 +105,7 @@ date: 27/09/2024 16:00
 - This thread will then be archived and a new one created for the next announcement.
 
 ## 10. **Action items**
+
 - Godfrey to email the Edinburgh Futures Institute to ask about event hosting and tour of place.
 - Godfrey to email the Nucleus as another option.
 - Godfrey to talk to Harsh about HTB last year.

--- a/constants/minutes/2024-10-04.md
+++ b/constants/minutes/2024-10-04.md
@@ -3,6 +3,7 @@ date: 4/10/2024 16:00
 ---
 
 ## **Attendees:**
+
 - Vincent
 - Godfrey
 - Marton
@@ -16,11 +17,13 @@ date: 4/10/2024 16:00
 - Lisa
 
 ## 1. **Good Things**
+
 - Qube Gold Sponsorship!
 - AISIG event (~ 110 people)!
 - Project Share event (~30 people)!
 
 ## 2. **Social Media Structuring & Event Promotion**
+
 - Lots of platforms to promote events and potentially too many announcements at a time / in once place
 - Need to agree on times to post things and where certain announcements go (Discord, Instagram, Newsletter)
 - Better communication with Agam/Lewis when planning an event
@@ -34,22 +37,26 @@ date: 4/10/2024 16:00
 - Hold interviews with potential candidates
 
 ## 3. **EGM**
+
 - Need to announce by next Wednesday (09.10.24)
 - Announce on discord, Instagram
 - Promote the EGM to first-years through tutors in the committee
 - Vincent announces to INF1A students with a slide in lecture
 
 ## 4. **Committee Chat / Roles**
+
 - Lots of "Legacy Committee" users (~30) who have admin positions and can delete channels
 - "Legacy Committee" users have gotten / will be upset if their roles are removed
 - Propose to remove "Legacy Committee" members roles and the role itself and ask active "Legacy Committee" members if they want to keep their roles
 - Having a committee discord will allow for multiple channels, without clogging the CompSoc one
 
 ## 5. **Careers Channel**
+
 - Propose to create a new server / more channels for careers
 - Companies want their events to be promoted over others
 
 ## 6. **AC Fams**
+
 - Send an email to parents / children about event ideas, changing families, where to get help
 - Set a week for each family to hold an event
 - Encourage people to have special family traits (colours, traditions)
@@ -57,4 +64,5 @@ date: 4/10/2024 16:00
 - If there is enough budget (unlikely) we can hold a large AC fams event in semester 1. Otherwise we can hold it semester 2
 
 ## 7. **Committee Social**
+
 - Potluck next Wednesday?

--- a/constants/minutes/2024-10-11.md
+++ b/constants/minutes/2024-10-11.md
@@ -3,6 +3,7 @@ date: 11/10/2024 16:00
 ---
 
 ## **Attendees:**
+
 - Vincent
 - Godfrey
 - Elisa
@@ -19,12 +20,14 @@ date: 11/10/2024 16:00
 - Lewis
 
 ## 1. **Promotions This Weekend**
+
 - Scheduled to be released on sunday
 - Deadline is end of today to be added to the post
 - The media used will be Discord and Instagram
 - We would like to humanities student for the future social media team
 
 ## 2. **Sponsor Update**
+
 - We have the following sponsors:
   - Optiver (Gold)
   - Qube Research and Technologies (Gold)
@@ -38,6 +41,7 @@ date: 11/10/2024 16:00
 - In summary, 2 Gold and 5 Silver so far
 
 ## 3. **InfBall**
+
 - Will be held in April, same time as last year
 - Pierre and Stan have volunteered to lead InfBall, with Marton and the first year rep as well
 - They will talk to the previous organisers for discussion
@@ -47,6 +51,7 @@ date: 11/10/2024 16:00
 - There is the possibility to increase the price of tickets
 
 ## 4. **Banking**
+
 - We are currently switching bank accounts from Santander to Bank of Scotland
 - This is still in process
 - We will get 3 debit cards from Bank of Scotland
@@ -54,27 +59,32 @@ date: 11/10/2024 16:00
 - Idea to use sub accounts for each SIG once switched to Bank of Scotland
 
 ## 5. **PhysSoc Halloween Party**
+
 - PhysSoc have not replied to Anastasia about the event
 - Event will be on the 29th of October
 - Desired attendance is 50
 - We will promote it as soon as possible especially since it is a ticketed event
 
 ## 6. **AdaHack Discussion**
+
 - £30 Amazon gift vouchers per person as prizes
 - We need 1/2 people throughout the event, and 2/3 people for judging at the end
 - Fergus, Tomas and Elisa volunteered
 
 ## 7. **Hoppers**
+
 - Hoppers expressed an interest to collaborate more with CompSoc
 - Hoppers and CompSoc combined hava a lot of reach
 - They want 2 events, one social and one technical workshop
 - We can both advertise these events to maximise attendance
 
 ## 8. **Neuphonic**
+
 - They do not get an STMU or HTB
 - They are not interested in the Expo
 - They woul like to run a Conversational AI themed Hackathon
 - They will handle the challenges, prizes and such, but would like CompSoc to do logistics
 
 ## 10. **Action items**
+
 - Find someone to run the Neuphonic event

--- a/constants/minutes/2024-11-15.md
+++ b/constants/minutes/2024-11-15.md
@@ -2,16 +2,18 @@
 date: 15/11/2024 15:00
 ---
 
-## **1. Good Things**  
-- **Neuophonic**: Event went very well.  
-- **Lloyds Payment**: Confirmed payment received.  
-- **Meta**:  
-  - Signed partnership.  
-  - Hosting an event focused on **infrastructure roles**.  
-  - Achieved **250+ clicks** on links for the Meta event.  
+## **1. Good Things**
+
+- **Neuophonic**: Event went very well.
+- **Lloyds Payment**: Confirmed payment received.
+- **Meta**:
+  - Signed partnership.
+  - Hosting an event focused on **infrastructure roles**.
+  - Achieved **250+ clicks** on links for the Meta event.
 - Reminder: Everyone should open the **Secret Santa link**.
 
-## **2. InfBall**  
-- Main focus: Securing the **venue**.  
-- **Options**:  
-  - Keeping venue names undisclosed to maintain **hype**.  
+## **2. InfBall**
+
+- Main focus: Securing the **venue**.
+- **Options**:
+  - Keeping venue names undisclosed to maintain **hype**.

--- a/constants/minutes/2024-11-22.md
+++ b/constants/minutes/2024-11-22.md
@@ -3,31 +3,34 @@ date: 22/11/2024 15:00
 ---
 
 ## **1. Fergus Updates**
-- Fergus has secured a **job in San Francisco** and may not be available next semester.  
-- Joining a **startup** from January to March.  
-- Potential need to **elect a new 3rd Year Representative** to fill the position during his absence.  
 
-## **2. Good Things**  
-- **Pub Quiz**: A lot of fun and well-received.  
-- **AI Expo**:  
-  - Excellent event, but noted challenges with large prizes.  
-  - **Recommendations**:  
-    - Conduct **judging before the public arrives** for smoother execution.  
-    - Allocate sufficient budget for **catering** (£1,400 spent, seen as crucial to event quality).  
-    - Use **lanyards with different colors** to categorize participants.  
-    - Implement **sign-ups before the event** to estimate attendance.  
-    - Keep providing **value throughout the event** to maintain engagement.  
-    - Develop a **clear rubric for judging** to ensure transparency and justification.  
+- Fergus has secured a **job in San Francisco** and may not be available next semester.
+- Joining a **startup** from January to March.
+- Potential need to **elect a new 3rd Year Representative** to fill the position during his absence.
+
+## **2. Good Things**
+
+- **Pub Quiz**: A lot of fun and well-received.
+- **AI Expo**:
+  - Excellent event, but noted challenges with large prizes.
+  - **Recommendations**:
+    - Conduct **judging before the public arrives** for smoother execution.
+    - Allocate sufficient budget for **catering** (£1,400 spent, seen as crucial to event quality).
+    - Use **lanyards with different colors** to categorize participants.
+    - Implement **sign-ups before the event** to estimate attendance.
+    - Keep providing **value throughout the event** to maintain engagement.
+    - Develop a **clear rubric for judging** to ensure transparency and justification.
     - Involve **industry professionals** as judges or lecturers to enhance credibility.
 
-## **3. Leo Updates**  
-- Discussed creating a **chill/hangout spot** for students, with features such as:  
-  - An **arcade machine**.  
-  - A **coffee/tea stand**.  
-  - **Ping pong tables** (new equipment is arriving in the café).  
-- **Concerns**:  
-  - The **university** is not prioritizing maintenance of **student satisfaction-related facilities**.  
-  - Suggested purchasing **better ping pong paddles and balls**.  
-  - **Food quality** was noted as good.  
-- **Limitations**: The **ground floor** is off-limits for modifications.  
-- **Suggestion:** Invest in items that are **low-maintenance** ("get and forget" purchases).  
+## **3. Leo Updates**
+
+- Discussed creating a **chill/hangout spot** for students, with features such as:
+  - An **arcade machine**.
+  - A **coffee/tea stand**.
+  - **Ping pong tables** (new equipment is arriving in the café).
+- **Concerns**:
+  - The **university** is not prioritizing maintenance of **student satisfaction-related facilities**.
+  - Suggested purchasing **better ping pong paddles and balls**.
+  - **Food quality** was noted as good.
+- **Limitations**: The **ground floor** is off-limits for modifications.
+- **Suggestion:** Invest in items that are **low-maintenance** ("get and forget" purchases).

--- a/constants/minutes/2024-11-29.md
+++ b/constants/minutes/2024-11-29.md
@@ -3,6 +3,7 @@ date: 29/11/2024 15:00
 ---
 
 ## **Attendees:**
+
 - Vincent
 - Godfrey
 - Elisa
@@ -22,40 +23,46 @@ date: 29/11/2024 15:00
 - Cat
 
 ## 1. **Good Things**
+
 - STMU: Successfully executed.
 - Week Before Hoppers Event: Fun and engaging
 - Snowball Fight: Well-received and enjoyed by attendees
 - Phil Wadler Content: Lewis did an excellent job with this
 
 ## 2. **HTB Recap**
+
 - Decision to proceed with Nucleus is likely
 - Awaiting response from the EFI representative
 - Funding Update: £1,000 received from DoraHacks
 
 ## 3. **Secret Santa**
+
 - 18 participants confirmed so far
 - The event date is undecided; more time is being given to finalize the schedule
 
 ## 4. **Mega STMU**
+
 - Speakers: Many exciting speakers but limited slots available
 - Consider two talks per STMU for greater engagement
 - Pair company talks with other speakers to keep events interesting for regular attendees
 - Combine the event with 25th Anniversary celebrations for a broader appeal
 
 ## 5. **Pub Golf Ideas**
+
 - Teams of 2-5 members with a sheet of challenges per team.
 - Proposed Challenges:
-    1. Doppelgängers: Take a picture in matching outfits (1 point).
-    2. Use zip ties for creative tasks (2 points).
-    3. Blindfold pub crawl (2 points, suggested by Vincent).
-    4. Outfit swap with teammates (1 point per swap).
-    5. Wear outfits backwards (1 point per person).
-    6. Build a human pyramid (5 points).
-    7. Use water guns for an assassin game (3 points per elimination).
-    8. Backward sprint against another team (1 point, max 1 race).
+  1. Doppelgängers: Take a picture in matching outfits (1 point).
+  2. Use zip ties for creative tasks (2 points).
+  3. Blindfold pub crawl (2 points, suggested by Vincent).
+  4. Outfit swap with teammates (1 point per swap).
+  5. Wear outfits backwards (1 point per person).
+  6. Build a human pyramid (5 points).
+  7. Use water guns for an assassin game (3 points per elimination).
+  8. Backward sprint against another team (1 point, max 1 race).
 - Prize Idea: Create the first CompSoc TikTok.
 
 ## 6. **Hoppers x CompSoc Year 1 Event**
+
 - Collaboration with Cat from Hoppers
 - Sunday, 8th December: Visit to the Christmas Market and a scavenger hunt
 - Staffing: Need two additional volunteers to assist

--- a/constants/minutes/2025-01-20.md
+++ b/constants/minutes/2025-01-20.md
@@ -3,6 +3,7 @@ date: 20/01/2025 16:15
 ---
 
 ## **Attendees:**
+
 - Vincent
 - Godfrey
 - Marton
@@ -19,30 +20,37 @@ date: 20/01/2025 16:15
 - Merlin
 
 ## 1. **STMU update**
+
 - Optiver would like metrics on numbers arriving for the workshop.
 - We will hold the EGM and advertise more to 3rd years to run for 3rd year rep
 
 ## 2. **HackTheBurgh Update**
+
 - Only thing left to do is create the website.
 - Once website is done we can open applications hopefully by 1st of Feb
 
 ## 3. **Socials Update**
+
 - Academic Families event is in the works
 - Open to ideas for other socials
 - Current idea is a group dance lesson
 
 ## 4. **InfBall Update**
+
 - Location has been finalised
 - Dates for release of tickets has been decided
 
 ## 5. **Sponsors Update**
+
 - More companies have been emailed.
 - Encode Club didn't go forward with sponsorship.
 
 ## 6. **Who wants the keys**
+
 - Giving out keys to the locker that has the key to the CompSoc cupboard
 - Vincent, Marton, Godfrey and Merlin have the keys
 
 ## 6. **Hackathon X**
+
 - Unknown sponsor woud like to run a hackathon
 - This is undecided, but may happen soon.

--- a/constants/minutes/2025-01-27.md
+++ b/constants/minutes/2025-01-27.md
@@ -3,6 +3,7 @@ date: 20/01/2025 16:15
 ---
 
 ## **Attendees:**
+
 - Vincent
 - Godfrey
 - Marton
@@ -15,6 +16,7 @@ date: 20/01/2025 16:15
 - Elisa
 
 ## 1. **STMU update**
+
 - Optiver will provide pizza, so most likely Papa John's.
 - Idea to use Civerino's for future STMUs.
 - Vincent will give out hugs to prize winners from Advent of Code.
@@ -22,20 +24,24 @@ date: 20/01/2025 16:15
 - We will test the code to access the member list on EUSA for the voting system.
 
 ## 2. **HackTheBurgh Update**
+
 - The website is up and accepting applications.
 - There was a brief period where the website went down but that is fixed.
 - Congratualtions were given to the tech team behind the website.
 
 ## 3. **Sponsors Update**
+
 - No further update on sponsors. No replies.
 
 ## 4. **InfBall Update**
+
 - Plans are set to release tickets and location this week.
 - No committee discount this year, but early access.
 - Staff have been invited separately.
 - No initial release for final year, however there are plenty of tickets so it is not a problem.
 
 ## 5. **Handovers**
+
 - We should provide good handovers for the next committee.
 - Use of the internal wiki and promotion of it would be ideal.
 - Should have a scheduled day to do one to one handovers.
@@ -44,6 +50,7 @@ date: 20/01/2025 16:15
 - Create a glossary of terms for easy access.
 
 ## 6. **Miscellaneous**
+
 - PwnEd will be run by SIGINT, conference and CTF.
 - We will provide teabags for the 6th floor.
 - We should find a suitable event to partner with Luxford Burgers.

--- a/constants/minutes/2025-02-24.md
+++ b/constants/minutes/2025-02-24.md
@@ -17,12 +17,11 @@ Apologies: Lewis
    this isn't really something that CompSoc does, since other SIGs are directly technology related,
    whereas EVP would only tangentially be related to tech. CompSoc will also be the first group to
    get the chance to support EVP should it go successfully.
-   
 3. Did CompSoc members turn up to their first event, if not, then isn't it unlikely that CompSoc
    members will enjoy it? Some CompSoc members did indeed show up, and it was suggested that EVP
    joining CompSoc as a SIG could help boost their numbers too. On a technical note, they already
    have the minimum required support of 10 members and a leader for creation of a SIG.
-   
+
 ## Other points
 
 It was mentioned that the startup fund of 500 GBP was pathetically low should it be spread amongst

--- a/constants/minutes/2025-03-10.md
+++ b/constants/minutes/2025-03-10.md
@@ -3,6 +3,7 @@ date: 10/03/2025 16:15
 ---
 
 **Attendees:**
+
 - Vincent
 - Godfrey
 - Elisa
@@ -19,6 +20,7 @@ date: 10/03/2025 16:15
 - Merlin
 
 ## 1. **HackTheBurgh Recap**
+
 - The event went very well, with large amounts of positive responses.
 - QRT and Optiver already interested in next year.
 - We will move it to October next semester to align with recruitment timelines.
@@ -30,6 +32,7 @@ date: 10/03/2025 16:15
 - Sponsorships will have to be dealt with before Summer.
 
 ## 2. **AGM Promotion**
+
 - Agam presents the social media plan.
 - We need someone with a staff card to print posters.
 - We gathered volunteers to do different parts of the plan.
@@ -39,6 +42,7 @@ date: 10/03/2025 16:15
 - Will do a story Q&A.
 
 ## 3. **Junior Treasurer Vote**
+
 - The vote is to add the Junior Treasurer role as an elected committee member in the constitution.
 - A Quroum was not met, so votes are still being collected.
 - From the meeting, 13 vote yes, 1 vote no.
@@ -46,6 +50,7 @@ date: 10/03/2025 16:15
 - The Junior Treasurer vote has been passed, so it will be added as an elected role.
 
 ## 4. **Events & Socials**
+
 - We would like to do an end of year party.
 - Location options could be: Bar50, Informatics Forum, IF Balcony.
 - Could also have a post-AGM party.
@@ -55,5 +60,6 @@ date: 10/03/2025 16:15
 - Idea to do another event open to everyone next week.
 
 ## 5. **InfBall Update**
+
 - Final ticket sales going out
 - Looking for volunteer to host raffle and come up with prizes

--- a/constants/minutes/2025-03-17.md
+++ b/constants/minutes/2025-03-17.md
@@ -3,6 +3,7 @@ date: 17/03/2025 16:15
 ---
 
 **Attendees:**
+
 - Vincent
 - Godfrey
 - Elisa
@@ -17,6 +18,7 @@ date: 17/03/2025 16:15
 - Tomas
 
 ## 1. **Updates on Socials**
+
 - On this week, we have the Academic families event.
 - No emails will be sent to the first years due to parents informing them.
 - Pub quiz on Thursday might be rescheduled due to communication issues between Hoppers and Bar 50.
@@ -26,6 +28,7 @@ date: 17/03/2025 16:15
 - There will also be a social for painting pottery.
 
 ## 2. **AGM Promotion Update**
+
 - Everything is going well do far.
 - Posters have been delayed.
 - Slides are being presented in lectures this week.
@@ -34,20 +37,24 @@ date: 17/03/2025 16:15
 - Committee should send videos for the committee reel ASAP.
 
 ## 3. **School x CompSoc Competition**
+
 - Pavlos from the School wants to make a competition that leverages Gen AI for teaching purposes.
 - Examples include marking, teaching and study guides.
 - The School will provide prizes and handle all logistics.
 - CompSoc will promote the event and provide a judge.
 
 ## 4. **Handover**
+
 - All committee should fill out the internal wiki prior to the AGM ideally, April 10th at the latest.
 
 ## 5. **Budget**
+
 - InfBall sales are over. More tickets were sold than expected.
 - We were underbudget for InfBall by £3000.
 - Ideas to either use this money for merch or for next year.
 
 ## 6. **Instagram Ideas**
+
 - There is an idea to create a close friends list for the Instagram stories.
 - People could be added through various events.
 - Informal behind the scenes of CompSoc events.

--- a/constants/minutes/2025-03-24.md
+++ b/constants/minutes/2025-03-24.md
@@ -3,6 +3,7 @@ date: 24/03/2025 16:15
 ---
 
 **Attendees:**
+
 - Vincent
 - Agam
 - Kacper
@@ -11,11 +12,13 @@ date: 24/03/2025 16:15
 - Charlotte
 
 ## 1. **Updates on Socials**
+
 - Three socials planned back to back, so plans to maybe move them.
 - This was caused by the Hoppers pub quiz being moved.
 - Arthur's Seat hike will be moved to Tuesday, 1st April.
 
 ## 2. **AGM Promotion Update**
+
 - Reel will be posted once videos are collected from committee.
 - This will be done by the 25th of March ideally.
 - Q&A instagram story on the 28th of March.
@@ -24,6 +27,7 @@ date: 24/03/2025 16:15
 - Email announcement on the 28th of March.
 
 ## 3. **Handover**
+
 - We should all write wiki entries for our roles.
 - We should have one-to-one handovers, explaining the role and important information.
 - We can let the new committee plan a social and help when they are confused or stuck.
@@ -32,7 +36,8 @@ date: 24/03/2025 16:15
 - This doc will be given to new committee to help run their first social.
 
 ## 4. **Discord Nitro**
+
 - Suppporting server boosts (assuming no-one boosts anymore) would cost more than what we spend on SIGs. Not financially viable.
 - We could consider rewarding those who boost the server with merch.
 - Ideas will be discussed further if Discord members are interested and when more committee are present.
-- Charlotte will talk to discord members. 
+- Charlotte will talk to discord members.

--- a/constants/minutes/2025-05-13.md
+++ b/constants/minutes/2025-05-13.md
@@ -1,9 +1,13 @@
 ---
 date: 2025-05-13T15:31
 ---
+
 # CompSoc Meeting Minutes 2025-05-13
+
 ## Attendees
+
 ### Committee - Quorate
+
 - President - **Kacper**
 - Vice President - **Anna**
 - Treasurer - **Kameran**
@@ -14,76 +18,95 @@ date: 2025-05-13T15:31
 - EDI Rep - **Charlotte**
 - 3rd Year Rep - **Anya**
 - Old Person Rep - **Uyi**
+
 ### SIG Reps
+
 - BetterInformatics - **Kshitij**
+
 ## Items
+
 ### Interim Social Sec
+
 - Anna says Param was running for VP, and wanted to support organising stuff - so he's also happy to be social sec.
 - Vote to appoint Param - **passed**
-	- In Favour
-		- 10/11
-	- Abstain
-		-  1/11
+  - In Favour
+    - 10/11
+  - Abstain
+    - 1/11
+
 ### Interim 4th Year Rep
+
 - Vote to appoint Vojtech - **passed**
-	- In Favour
-		- 10/11
-	- Abstain
-		-  1/11
-### BetterInformatics offsite backups 
+  - In Favour
+    - 10/11
+  - Abstain
+    - 1/11
+
+### BetterInformatics offsite backups
+
 - Kshitij: BI is used by a huge number of people and is hosted on Tardis without backups - small risk but a major problem
 - Looking to scale up and expand to more courses (maths etc), to 150+ courses
 - Asking for £300 for £5 or so a month for offsite backups
 - Kameran: why 300?
-	- Kshitij: It's a higher estimate, and might only be used if Tardis goes down
+  - Kshitij: It's a higher estimate, and might only be used if Tardis goes down
 - Kameran: how much would it cost when Tardis goes down?
-	- Kshitij: Will look into this after end of exams
+  - Kshitij: Will look into this after end of exams
 - £120 base agreed £10/month, will look into more after exams (£120-300 estimate)
 - And a request to get feedback from people
-### Committee Hoodies 
+
+### Committee Hoodies
+
 - Considering variations of hoodies
 - SIGINT and Tardis also wants hoodies - order in bulk?
-	- Will see basically, might not be a benefit
+  - Will see basically, might not be a benefit
 - Probably the same design, maybe a different colour
 - Stick with the same supplier
+
 ### Technical Infrastructure Changes - Emily
+
 - Wiki
-	- Updating what we actually do
-	- And what services we have
+  - Updating what we actually do
+  - And what services we have
 - Discord
-	- Moved over committee role labels
-	- Could create Year-rep roles
+  - Moved over committee role labels
+  - Could create Year-rep roles
 - Website
-	- Could committee members send photos and socials to update the website
+  - Could committee members send photos and socials to update the website
 - Moving Vault warden and Wiki to a specific VM
 - And sorting out old HTB VMs - save money
+
 ### First Social Event
+
 - Want to hold before end of semester
 - What: BBQ in the meadows
-- When: 24th May provisionally 
+- When: 24th May provisionally
 - Will need Param onboard
 - Involve some activities (card games etc)
+
 ### Welcome Week
-- Need to give EUSA approximate dates next week 
+
+- Need to give EUSA approximate dates next week
 - Events that happen every year:
-	- Activities fair booth (EUSA managed)
-	- Photo scavenger hunt
-	- Arthur's Seat Hike
-		- Will need someone who knows route (Alex volunteered) and first aider
-	- Gamesoc LAN
-		- Bring in games consoles and book AT floor 4
-		- Order pizza and drinks
-	- Pub crawl
-		- Teams challenge to get the hat
+  - Activities fair booth (EUSA managed)
+  - Photo scavenger hunt
+  - Arthur's Seat Hike
+    - Will need someone who knows route (Alex volunteered) and first aider
+  - Gamesoc LAN
+    - Bring in games consoles and book AT floor 4
+    - Order pizza and drinks
+  - Pub crawl
+    - Teams challenge to get the hat
 - Sig events
-	- Sigint, workshops, etc
+  - Sigint, workshops, etc
 - Maybe another flesh market BBQ?
 - Social sec normally adds another thing
+
 ## Actions
+
 - Reach out to Param and Vojtech
 - Update Param on social plans
 - First Social - announced by 17th
-	- Graphics
-	- Social media posts
-	- Year rep outreach
+  - Graphics
+  - Social media posts
+  - Year rep outreach
 - Think about welcome week events

--- a/constants/news/2024-10-07-oct-stmu-egm.md
+++ b/constants/news/2024-10-07-oct-stmu-egm.md
@@ -25,7 +25,7 @@ The positions we're electing are:
 
   - Organises monthly STMUs and other miscellaneous events with our sponsors.
   - Oversees working with our SIGs (Special Interest Groups).
-  
+
 - **Junior Treasurer**
 
   - Manage daily financial operations - including making reimbursements, maintaining budgets, and tracking transactions.
@@ -37,7 +37,6 @@ The positions we're electing are:
   - Responsible for communication between their year and the Society, and promotes events to their year.
   - Responsible for organising some of CompSoc's large projects and events, such as InfBall, HackTheBurgh or pwnedEd.
   - Gain an insight into the day-to-day of running CompSoc, and valuable experience in organising large scale society events.
-  
 
 If you are interested in applying for any of these positions, you need to:
 
@@ -49,7 +48,7 @@ Although it is possible to run impromptu on the day, submitting a manifesto will
 
 ### Student Tech Meet-Up
 
-[Shiu Ka Heng](https://shiukaheng.com/), a graduate from Edinburgh will take us through "The Lost Metropolis: Immortalizing Hong Kong's Changing Landscapes in Virtual Reality."  
+[Shiu Ka Heng](https://shiukaheng.com/), a graduate from Edinburgh will take us through "The Lost Metropolis: Immortalizing Hong Kong's Changing Landscapes in Virtual Reality."
 
 Join us for a deep dive into how this interdisciplinary project is tackling the challenge of digitally preserving Hong Kong's urban spaces threatened by redevelopment. Discover the art and science behind large-scale 3D reconstruction, from robotics development for autonomous 3D capture to employing advanced techniques like Gaussian splatting. Heng will share insights into the project's journey, the hurdles overcome, and the latest in 3D reconstruction technology.
 

--- a/constants/news/2024-10-10-oct-egm-manifestos.md
+++ b/constants/news/2024-10-10-oct-egm-manifestos.md
@@ -41,18 +41,18 @@ We also allow people to run on the night, if you did not have time to create man
 
 _The views expressed on the following manifestos are the candidates' own and do not represent those of CompSoc. They are hosted here for the purposes of facilitating EUSA elections._
 
-| Role                     | Name                   | Manifesto Link                                                                                       |
-| ------------------------ | ---------------------- | ---------------------------------------------------------------------------------------------------- |
-| **Vice-President**       | Marton Nemeth          | [Link](https://drive.google.com/file/d/1rV4ZqVyTL2Vh2lzdlKtXtarCV0XH_fNE/view?usp=sharing) |
-| **Junior Treasurer**     | Weng Kin Chan       | [Link](https://drive.google.com/file/d/1s0vENluG5VjjZch7q1RvYpePvDSYqkCL/view?usp=sharing) |
-|      | Anna Kandyba       | [Link](https://drive.google.com/file/d/1J9AvYlDat4ho4sm3YYDXsUmWyYSnsNzy/view?usp=sharing) |
-|      | Arthur Sokolov       | [Link](https://drive.google.com/file/d/10D-MQ6mfkrBGjA-KWImWgnmZo0Wi_zlD/view?usp=sharing) |
-|      | Eileen Garip       | [Link](https://drive.google.com/file/d/1ye1jEofYcIXIq8yL71IEOXBgGKbRxHJP/view?usp=sharing) |
-|      | Kameran Russell       | [Link](https://drive.google.com/file/d/1XxL8hjes4ZPh5Xv0QvbFv3Gse_m3KxMr/view?usp=sharing) |
-| **1st Year Rep**         | Kacper Szymanski       | [Link](https://drive.google.com/file/d/1xMs7pPZf1Seaf1XnQxRVRvfjqA0b_qVw/view?usp=sharing) |
-|                          | Hyunseo Lee       | [Link](https://drive.google.com/file/d/1FcF5N7XPJako5veWNXTQ9cs7Q9UUKPlf/view?usp=sharing) |
-|                          | Shlok Gupta       | [Link](https://drive.google.com/file/d/1YU16mNMtOKzlRgkH1D5L8d8yy-I3klSA/view?usp=sharing) |
-|                          | Archie Spiller       | [Link](https://drive.google.com/file/d/1usevnaYtJsrB_eCDCE4301bAOdrK4GV1/view?usp=sharing) |
+| Role                 | Name             | Manifesto Link                                                                             |
+| -------------------- | ---------------- | ------------------------------------------------------------------------------------------ |
+| **Vice-President**   | Marton Nemeth    | [Link](https://drive.google.com/file/d/1rV4ZqVyTL2Vh2lzdlKtXtarCV0XH_fNE/view?usp=sharing) |
+| **Junior Treasurer** | Weng Kin Chan    | [Link](https://drive.google.com/file/d/1s0vENluG5VjjZch7q1RvYpePvDSYqkCL/view?usp=sharing) |
+|                      | Anna Kandyba     | [Link](https://drive.google.com/file/d/1J9AvYlDat4ho4sm3YYDXsUmWyYSnsNzy/view?usp=sharing) |
+|                      | Arthur Sokolov   | [Link](https://drive.google.com/file/d/10D-MQ6mfkrBGjA-KWImWgnmZo0Wi_zlD/view?usp=sharing) |
+|                      | Eileen Garip     | [Link](https://drive.google.com/file/d/1ye1jEofYcIXIq8yL71IEOXBgGKbRxHJP/view?usp=sharing) |
+|                      | Kameran Russell  | [Link](https://drive.google.com/file/d/1XxL8hjes4ZPh5Xv0QvbFv3Gse_m3KxMr/view?usp=sharing) |
+| **1st Year Rep**     | Kacper Szymanski | [Link](https://drive.google.com/file/d/1xMs7pPZf1Seaf1XnQxRVRvfjqA0b_qVw/view?usp=sharing) |
+|                      | Hyunseo Lee      | [Link](https://drive.google.com/file/d/1FcF5N7XPJako5veWNXTQ9cs7Q9UUKPlf/view?usp=sharing) |
+|                      | Shlok Gupta      | [Link](https://drive.google.com/file/d/1YU16mNMtOKzlRgkH1D5L8d8yy-I3klSA/view?usp=sharing) |
+|                      | Archie Spiller   | [Link](https://drive.google.com/file/d/1usevnaYtJsrB_eCDCE4301bAOdrK4GV1/view?usp=sharing) |
 
 We hope you think carefully about who you choose to elect tonight — please vote based on manifestos and speeches! Note that you may also vote for RON (reopen nominations) for all positions. You also need EUSA CompSoc membership.
 

--- a/constants/news/2025-01-26-jan-egm-manifestos.md
+++ b/constants/news/2025-01-26-jan-egm-manifestos.md
@@ -5,8 +5,8 @@ excerpt_separator: '<!--See More-->'
 roles:
   - title: Third Year Rep
     people:
-      - name: 
-        url: 
+      - name:
+        url:
 ---
 
 ## Election Details
@@ -19,9 +19,9 @@ We also allow people to run on the night, if you did not have time to create man
 
 _The views expressed on the following manifestos are the candidates' own and do not represent those of CompSoc. They are hosted here for the purposes of facilitating EUSA elections._
 
-| Role                     | Name                   | Manifesto Link                                                                                       |
-| ------------------------ | ---------------------- | ---------------------------------------------------------------------------------------------------- |
-| **Third Year Rep**       | Nobody has run for this position yet!        |  |
+| Role               | Name                                  | Manifesto Link |
+| ------------------ | ------------------------------------- | -------------- |
+| **Third Year Rep** | Nobody has run for this position yet! |                |
 
 We hope you think carefully about who you choose to elect tonight — please vote based on manifestos and speeches! Note that you may also vote for RON (reopen nominations) for all positions. You also need EUSA CompSoc membership.
 

--- a/constants/news/2025-01-26-jan-stmu-egm.md
+++ b/constants/news/2025-01-26-jan-stmu-egm.md
@@ -13,9 +13,8 @@ In the second half of our next STMU on the 29th of January 18:00-21:00, we will 
 
 The **Third Year Representative** is:
 
-  - Responsible for communication between their years and the Society, and promotes events to their year.
-  - Also responsible for any projects they take up throughout the year.
-
+- Responsible for communication between their years and the Society, and promotes events to their year.
+- Also responsible for any projects they take up throughout the year.
 
 ### Want to run for the position?
 

--- a/constants/news/2025-02-27-april-agm-manifestos.md
+++ b/constants/news/2025-02-27-april-agm-manifestos.md
@@ -36,19 +36,19 @@ roles:
       - name: Kay
         url: https://drive.google.com/file/d/1GKcUs92ABqKCjLRIkOjhj516cB_eXk3d/view?usp=sharing
   - title: TechSec
-    people: 
+    people:
       - name: Carl Kaziboni
         url: https://drive.google.com/file/d/10i7vu7yKILaWcFx0m-eIz0xzz5NJYkdX/view?usp=sharing
       - name: Weng Kin Chan
         url: https://drive.google.com/file/d/11JW56x6ZSRXTQkdaxXJ37pNfmzWLpZZe/view?usp=sharing
   - title: SocialSec
     people:
-      - name: 
-        url: 
+      - name:
+        url:
   - title: Social Media Officer
     people:
-      - name: 
-        url: 
+      - name:
+        url:
   - title: 2nd Year Rep
     people:
       - name: Danyil Butov
@@ -59,12 +59,12 @@ roles:
         url: https://drive.google.com/file/d/1obA-RzZ8MVmY7TfHdAZG1aaqogBrGu_o/view?usp=sharing
   - title: 3rd Year Rep
     people:
-      - name: 
-        url: 
+      - name:
+        url:
   - title: 4th Year Rep
     people:
-      - name: 
-        url: 
+      - name:
+        url:
   - title: Old Person Rep
     people:
       - name: Uyi Lavrentieva
@@ -85,35 +85,34 @@ We also allow people to run on the night, if you did not have time to create man
 
 _The views expressed on the following manifestos are the candidates' own and do not represent those of CompSoc. They are hosted here for the purposes of facilitating EUSA elections._
 
-| Role                     | Name                   | Manifesto Link                                                                                       |
-| ------------------------ | ---------------------- | ---------------------------------------------------------------------------------------------------- |
-| **President**            | Kacper Szymanski  | [Link](https://drive.google.com/file/d/1SvhclULogysVGBtYkwj_nOBJfKHwWlsP/view?usp=sharing) |
-|                          | Kian Hampson-Bahia| [Link](https://drive.google.com/file/d/1UOklQJU07hdZxdh-saTbhFaff1emDK9i/view?usp=sharing) |
-| **Vice-President**       | Archie Spiller | [Link](https://drive.google.com/file/d/1Qvb4Q77zTW30mmTjkivl33BkQ5cZJnHK/view?usp=sharing) |
-|                          | Anna Petrusenko| [Link](https://drive.google.com/file/d/1rVzdTyd4QsPl1UAYncYMmBdp-q9NbSnJ/view?usp=sharing) |
-|                          | Param Mansukhani | [Link](https://drive.google.com/file/d/1JBuoHQZBCb0uRgozl2A9GPCfeayJZFzG/view?usp=sharing) |
-| **Secretary**            | Alex Davis | [Link](https://drive.google.com/file/d/1rBtUwqCPqgiC-iZm9TmqefJytnHfF4ho/view?usp=sharing) |
-|                          | Manthan Chugh | [Link](https://drive.google.com/file/d/1hjvLylNfRiJKuFtLbJmSmhqSVE85ozWG/view?usp=sharing) |
-| **Treasurer**            | Yurii Ilnytksyi | [Link](https://drive.google.com/file/d/1gIAfP4KRKUiS6XhEZigB9ktIWrZVfi-Y/view?usp=sharing) |
-|                          | Kameran Russell | [Link](https://drive.google.com/file/d/1Lc3GW1aYURNByRh5T4J-Z27EIXGNm30j/view?usp=sharing) |
-| **Graphic Designer**     | Hyunseo Lee | [Link](https://drive.google.com/file/d/1kd9jhvbxWfJyguR8QWRD86xGT7tQlkMd/view?usp=sharing) |
-|                          | Kay         | [Link](https://drive.google.com/file/d/1GKcUs92ABqKCjLRIkOjhj516cB_eXk3d/view?usp=sharing) |
-| **TechSec**              | Carl Kaziboni | [Link](https://drive.google.com/file/d/10i7vu7yKILaWcFx0m-eIz0xzz5NJYkdX/view?usp=sharing) |
-|                          | Weng Kin Chan | [Link](https://drive.google.com/file/d/11JW56x6ZSRXTQkdaxXJ37pNfmzWLpZZe/view?usp=sharing) |
-| **SocialSec**            | Nobody has run for this position yet! |  |
-| **Social Media Officer** | Nobody has run for this position yet! |  |
-| **2nd Year Rep**         | Danyil Butov | [Link](https://drive.google.com/file/d/19LSw2WWHvzIsrfKPIrPJP0meXdxJMFce/view?usp=sharing) |
-|                          | Eileen Garip | [Link](https://drive.google.com/file/d/11D6c-t8WNKHt7kvsYbwB-cHfz9aQh9tm/view?usp=sharing) |
-|                          | Abdulwahid | [Link](https://drive.google.com/file/d/1obA-RzZ8MVmY7TfHdAZG1aaqogBrGu_o/view?usp=sharing) |
-| **3rd Year Rep**         | Nobody has run for this position yet! |  |
-| **4th Year Rep**         | Nobody has run for this position yet! |  |
-| **Old Person Rep**       | Uyi Lavrentieva | [Link](https://drive.google.com/file/d/1aoGVdI0_ATkifQnOo5NOGBlWPTjBcH3K/view?usp=sharing) |
-| **EDI Rep**              | Sorana Ionescu | [Link](https://drive.google.com/file/d/1pZOQFZNWwVR2JjX7hIvWvdj-pGG0ydbd/view?usp=sharing) |
+| Role                     | Name                                  | Manifesto Link                                                                             |
+| ------------------------ | ------------------------------------- | ------------------------------------------------------------------------------------------ |
+| **President**            | Kacper Szymanski                      | [Link](https://drive.google.com/file/d/1SvhclULogysVGBtYkwj_nOBJfKHwWlsP/view?usp=sharing) |
+|                          | Kian Hampson-Bahia                    | [Link](https://drive.google.com/file/d/1UOklQJU07hdZxdh-saTbhFaff1emDK9i/view?usp=sharing) |
+| **Vice-President**       | Archie Spiller                        | [Link](https://drive.google.com/file/d/1Qvb4Q77zTW30mmTjkivl33BkQ5cZJnHK/view?usp=sharing) |
+|                          | Anna Petrusenko                       | [Link](https://drive.google.com/file/d/1rVzdTyd4QsPl1UAYncYMmBdp-q9NbSnJ/view?usp=sharing) |
+|                          | Param Mansukhani                      | [Link](https://drive.google.com/file/d/1JBuoHQZBCb0uRgozl2A9GPCfeayJZFzG/view?usp=sharing) |
+| **Secretary**            | Alex Davis                            | [Link](https://drive.google.com/file/d/1rBtUwqCPqgiC-iZm9TmqefJytnHfF4ho/view?usp=sharing) |
+|                          | Manthan Chugh                         | [Link](https://drive.google.com/file/d/1hjvLylNfRiJKuFtLbJmSmhqSVE85ozWG/view?usp=sharing) |
+| **Treasurer**            | Yurii Ilnytksyi                       | [Link](https://drive.google.com/file/d/1gIAfP4KRKUiS6XhEZigB9ktIWrZVfi-Y/view?usp=sharing) |
+|                          | Kameran Russell                       | [Link](https://drive.google.com/file/d/1Lc3GW1aYURNByRh5T4J-Z27EIXGNm30j/view?usp=sharing) |
+| **Graphic Designer**     | Hyunseo Lee                           | [Link](https://drive.google.com/file/d/1kd9jhvbxWfJyguR8QWRD86xGT7tQlkMd/view?usp=sharing) |
+|                          | Kay                                   | [Link](https://drive.google.com/file/d/1GKcUs92ABqKCjLRIkOjhj516cB_eXk3d/view?usp=sharing) |
+| **TechSec**              | Carl Kaziboni                         | [Link](https://drive.google.com/file/d/10i7vu7yKILaWcFx0m-eIz0xzz5NJYkdX/view?usp=sharing) |
+|                          | Weng Kin Chan                         | [Link](https://drive.google.com/file/d/11JW56x6ZSRXTQkdaxXJ37pNfmzWLpZZe/view?usp=sharing) |
+| **SocialSec**            | Nobody has run for this position yet! |                                                                                            |
+| **Social Media Officer** | Nobody has run for this position yet! |                                                                                            |
+| **2nd Year Rep**         | Danyil Butov                          | [Link](https://drive.google.com/file/d/19LSw2WWHvzIsrfKPIrPJP0meXdxJMFce/view?usp=sharing) |
+|                          | Eileen Garip                          | [Link](https://drive.google.com/file/d/11D6c-t8WNKHt7kvsYbwB-cHfz9aQh9tm/view?usp=sharing) |
+|                          | Abdulwahid                            | [Link](https://drive.google.com/file/d/1obA-RzZ8MVmY7TfHdAZG1aaqogBrGu_o/view?usp=sharing) |
+| **3rd Year Rep**         | Nobody has run for this position yet! |                                                                                            |
+| **4th Year Rep**         | Nobody has run for this position yet! |                                                                                            |
+| **Old Person Rep**       | Uyi Lavrentieva                       | [Link](https://drive.google.com/file/d/1aoGVdI0_ATkifQnOo5NOGBlWPTjBcH3K/view?usp=sharing) |
+| **EDI Rep**              | Sorana Ionescu                        | [Link](https://drive.google.com/file/d/1pZOQFZNWwVR2JjX7hIvWvdj-pGG0ydbd/view?usp=sharing) |
 
 We hope you think carefully about who you choose to elect tonight — please vote based on manifestos and speeches! Note that you may also vote for RON (reopen nominations) for all positions. You also need EUSA CompSoc membership.
 
 Election candidates - please remember that if you are running for President, Secretary, or Treasurer, your speech may be up to 2 minutes. Other roles have up to 1 minute. If you haven't gotten membership yet, **do that now**!
-
 
 See you on April 2nd,
 

--- a/constants/news/2025-02-27-april-agm.md
+++ b/constants/news/2025-02-27-april-agm.md
@@ -12,7 +12,7 @@ The positions available are: President, Vice-President, Secretary, Treasurer, Te
 
 ### Want to run for a position?
 
-- (*Optional*) Send committee@comp-soc.com your manifesto (PDF of max 200 words) **by 8:00 PM Tuesday, 1st April 2025** specifying your full name and the role in the title (not included in word count).
+- (_Optional_) Send committee@comp-soc.com your manifesto (PDF of max 200 words) **by 8:00 PM Tuesday, 1st April 2025** specifying your full name and the role in the title (not included in word count).
 - Prepare a speech. Length is 2 minutes for executive roles (President, Secretary, Treasurer) and 1 minute for the other roles. You may get asked questions afterwards.
 
 You can view the submitted manifestos for all roles [here](https://comp-soc.com/news/2025-02-27-april-agm-manifestos/)


### PR DESCRIPTION
• Improved Markdown rendering for the Minutes/News pages
• Added breadcrumbs for easier navigation
• Added year-based filters

Attached are some screenshots of the refreshed design:
<img width="1512" alt="Screenshot 2025-06-03 at 20 56 46" src="https://github.com/user-attachments/assets/313b1b27-07fa-45d8-a2c0-a4c65d22431b" />
<img width="1512" alt="Screenshot 2025-06-03 at 20 56 39" src="https://github.com/user-attachments/assets/4aa12ef9-15f8-4d7c-a73f-e9ab2a6fe69e" />
