### PR TITLE
Remove preview from News and Minutes Pages

### DIFF
--- a/app/minutes/MinutesList.tsx
+++ b/app/minutes/MinutesList.tsx
@@ -125,17 +125,6 @@ const ListView = ({
                 </span>
               </div>
             </div>
-            <p
-              className="text-sm opacity-70 leading-relaxed mt-2"
-              style={{
-                display: '-webkit-box',
-                WebkitLineClamp: 2,
-                WebkitBoxOrient: 'vertical',
-                overflow: 'hidden',
-              }}
-            >
-              {post.content.slice(0, 180)}...
-            </p>
           </div>
         </Link>
       ))}

--- a/app/news/NewsList.tsx
+++ b/app/news/NewsList.tsx
@@ -126,17 +126,6 @@ const ListView = ({
                 </span>
               </div>
             </div>
-            <p
-              className="text-sm opacity-70 leading-relaxed mt-2"
-              style={{
-                display: '-webkit-box',
-                WebkitLineClamp: 2,
-                WebkitBoxOrient: 'vertical',
-                overflow: 'hidden',
-              }}
-            >
-              {post.content.slice(0, 180)}...
-            </p>
           </div>
         </Link>
       ))}


### PR DESCRIPTION
### News:
#### Old:
<img width="1914" height="965" alt="screenshot of existing news page" src="https://github.com/user-attachments/assets/5dab5dc5-8e62-4efa-b4c8-64ab7f7f7549" />

#### New:
<img width="1914" height="965" alt="screenshot of proposed news page with previews removed" src="https://github.com/user-attachments/assets/ed0882f7-05dd-4095-9338-3218f2eaf0a3" />

### Minutes:
#### Old:
<img width="1914" height="965" alt="screenshot of existing minutes page" src="https://github.com/user-attachments/assets/59e788f3-1c6e-4b3f-be3d-f4e0043244d3" />


#### New:
<img width="1914" height="965" alt="screenshot of proposed minutes page with previews removed" src="https://github.com/user-attachments/assets/8c400065-50ab-4419-87cb-cdc09dc66dd4" />

Closes: #54 