### PR TITLE
Repair "Add Master's Rep role and Update 2025 team"

### DIFF
--- a/constants/team/team2025.ts
+++ b/constants/team/team2025.ts
@@ -199,7 +199,7 @@ export const team2025: Committee[] = [
     ],
   },
   {
-    name: "Pa'uk",
+    name: 'Pa\'uk',
     surname: '',
     role: Role.OLD_PERSON_REP,
     links: [],
@@ -241,21 +241,6 @@ export const team2025: Committee[] = [
       {
         type: LinkType.INSTAGRAM,
         url: 'https://www.instagram.com/kaiwen.wang_',
-      },
-    ],
-  },
-  {
-    name: 'Farhaan',
-    surname: 'Mukarram',
-    role: Role.MASTERS_REP,
-    links: [
-      {
-        type: LinkType.LINKEDIN,
-        url: 'https://www.linkedin.com/in/farhaan-mukarram',
-      },
-      {
-        type: LinkType.GITHUB,
-        url: 'https://github.com/farhaan-mukarram ',
       },
     ],
   },

--- a/lib/committee/constants/index.ts
+++ b/lib/committee/constants/index.ts
@@ -20,7 +20,6 @@ export const ROLE_EMAILS: Record<Role, Nullable<string>> = {
   [Role.SECOND_YEAR_REP]: 'secondrep@comp-soc.com',
   [Role.THIRD_YEAR_REP]: 'thirdrep@comp-soc.com',
   [Role.FOURTH_YEAR_REP]: 'fourthrep@comp-soc.com',
-  [Role.MASTERS_REP]: 'mastersrep@comp-soc.com',
   [Role.OLD_PERSON_REP]: 'oldrep@comp-soc.com',
   [Role.EDI_REP]: 'edirep@comp-soc.com',
   [Role.IMAGE_AND_PR]: null,

--- a/lib/committee/constants/role.ts
+++ b/lib/committee/constants/role.ts
@@ -14,7 +14,6 @@ export enum Role {
   SECOND_YEAR_REP = '2nd Year Rep',
   THIRD_YEAR_REP = '3rd Year Rep',
   FOURTH_YEAR_REP = '4th Year Rep',
-  MASTERS_REP = `Master's Rep`,
   OLD_PERSON_REP = 'Old Person Rep',
   EDI_REP = 'EDI Rep',
   IMAGE_AND_PR = 'Image and PR',


### PR DESCRIPTION
Reverts compsoc-edinburgh/comp-soc.com#56

Pa'uk's name had \' replaced with just ' which, currently, is not an issue but for peace of mind I'm returning it.